### PR TITLE
fix: npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,6 @@ on:
 jobs:
   release:
     runs-on: macos-latest
-
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -30,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
           scope: '@trust0'
           cache: 'npm'
@@ -70,13 +66,13 @@ jobs:
           
       - name: Run Build package
         env:
-          NPM_TOKEN: ${{ env.NPM_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ steps.import_gpg.outputs.email }}
           GIT_COMMITTER_EMAIL: ${{ steps.import_gpg.outputs.email }}
           GIT_AUTHOR_NAME: ${{ steps.import_gpg.outputs.name }}
           GIT_COMMITTER_NAME: ${{ steps.import_gpg.outputs.name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: |
           yarn install
           npm run build

--- a/docs/@trust0/ridb-core/classes/BasePlugin.md
+++ b/docs/@trust0/ridb-core/classes/BasePlugin.md
@@ -6,7 +6,7 @@
 
 # Class: BasePlugin
 
-Defined in: ridb\_core.d.ts:243
+Defined in: ridb\_core.d.ts:522
 
 ## Implements
 
@@ -28,7 +28,7 @@ Defined in: ridb\_core.d.ts:243
 
 > `optional` **docCreateHook**: [`Hook`](../type-aliases/Hook.md)
 
-Defined in: ridb\_core.d.ts:244
+Defined in: ridb\_core.d.ts:523
 
 #### Implementation of
 
@@ -40,7 +40,7 @@ Defined in: ridb\_core.d.ts:244
 
 > `optional` **docRecoverHook**: [`Hook`](../type-aliases/Hook.md)
 
-Defined in: ridb\_core.d.ts:245
+Defined in: ridb\_core.d.ts:524
 
 #### Implementation of
 

--- a/docs/@trust0/ridb-core/classes/BasePlugin.md
+++ b/docs/@trust0/ridb-core/classes/BasePlugin.md
@@ -6,7 +6,7 @@
 
 # Class: BasePlugin
 
-Defined in: ridb\_core.d.ts:387
+Defined in: ridb\_core.d.ts:645
 
 ## Implements
 
@@ -28,7 +28,7 @@ Defined in: ridb\_core.d.ts:387
 
 > `optional` **docCreateHook**: [`Hook`](../type-aliases/Hook.md)
 
-Defined in: ridb\_core.d.ts:388
+Defined in: ridb\_core.d.ts:646
 
 #### Implementation of
 
@@ -40,7 +40,7 @@ Defined in: ridb\_core.d.ts:388
 
 > `optional` **docRecoverHook**: [`Hook`](../type-aliases/Hook.md)
 
-Defined in: ridb\_core.d.ts:389
+Defined in: ridb\_core.d.ts:647
 
 #### Implementation of
 

--- a/docs/@trust0/ridb-core/classes/BasePlugin.md
+++ b/docs/@trust0/ridb-core/classes/BasePlugin.md
@@ -6,7 +6,7 @@
 
 # Class: BasePlugin
 
-Defined in: ridb\_core.d.ts:522
+Defined in: ridb\_core.d.ts:387
 
 ## Implements
 
@@ -28,7 +28,7 @@ Defined in: ridb\_core.d.ts:522
 
 > `optional` **docCreateHook**: [`Hook`](../type-aliases/Hook.md)
 
-Defined in: ridb\_core.d.ts:523
+Defined in: ridb\_core.d.ts:388
 
 #### Implementation of
 
@@ -40,7 +40,7 @@ Defined in: ridb\_core.d.ts:523
 
 > `optional` **docRecoverHook**: [`Hook`](../type-aliases/Hook.md)
 
-Defined in: ridb\_core.d.ts:524
+Defined in: ridb\_core.d.ts:389
 
 #### Implementation of
 

--- a/docs/@trust0/ridb-core/classes/BasePlugin.md
+++ b/docs/@trust0/ridb-core/classes/BasePlugin.md
@@ -6,7 +6,7 @@
 
 # Class: BasePlugin
 
-Defined in: ridb\_core.d.ts:645
+Defined in: ridb\_core.d.ts:388
 
 ## Implements
 
@@ -28,7 +28,7 @@ Defined in: ridb\_core.d.ts:645
 
 > `optional` **docCreateHook**: [`Hook`](../type-aliases/Hook.md)
 
-Defined in: ridb\_core.d.ts:646
+Defined in: ridb\_core.d.ts:389
 
 #### Implementation of
 
@@ -40,7 +40,7 @@ Defined in: ridb\_core.d.ts:646
 
 > `optional` **docRecoverHook**: [`Hook`](../type-aliases/Hook.md)
 
-Defined in: ridb\_core.d.ts:647
+Defined in: ridb\_core.d.ts:390
 
 #### Implementation of
 

--- a/docs/@trust0/ridb-core/classes/BaseStorage.md
+++ b/docs/@trust0/ridb-core/classes/BaseStorage.md
@@ -6,7 +6,7 @@
 
 # Class: BaseStorage\<Schemas\>
 
-Defined in: ridb\_core.d.ts:402
+Defined in: ridb\_core.d.ts:199
 
 ## Extends
 
@@ -29,7 +29,7 @@ Defined in: ridb\_core.d.ts:402
 
 > **new BaseStorage**\<`Schemas`\>(`dbName`, `schemas`, `options?`): `BaseStorage`\<`Schemas`\>
 
-Defined in: ridb\_core.d.ts:412
+Defined in: ridb\_core.d.ts:209
 
 #### Parameters
 
@@ -59,7 +59,7 @@ Defined in: ridb\_core.d.ts:412
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:420
+Defined in: ridb\_core.d.ts:217
 
 ***
 
@@ -67,7 +67,7 @@ Defined in: ridb\_core.d.ts:420
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:417
+Defined in: ridb\_core.d.ts:214
 
 ***
 
@@ -75,7 +75,7 @@ Defined in: ridb\_core.d.ts:417
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:419
+Defined in: ridb\_core.d.ts:216
 
 ***
 
@@ -83,7 +83,7 @@ Defined in: ridb\_core.d.ts:419
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:418
+Defined in: ridb\_core.d.ts:215
 
 ## Methods
 
@@ -91,7 +91,7 @@ Defined in: ridb\_core.d.ts:418
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:430
+Defined in: ridb\_core.d.ts:227
 
 #### Returns
 
@@ -103,7 +103,7 @@ Defined in: ridb\_core.d.ts:430
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:422
+Defined in: ridb\_core.d.ts:219
 
 #### Returns
 
@@ -119,7 +119,7 @@ Defined in: ridb\_core.d.ts:422
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:423
+Defined in: ridb\_core.d.ts:220
 
 #### Parameters
 
@@ -149,7 +149,7 @@ keyof `Schemas`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:425
+Defined in: ridb\_core.d.ts:222
 
 #### Parameters
 
@@ -179,7 +179,7 @@ keyof `Schemas`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:424
+Defined in: ridb\_core.d.ts:221
 
 #### Parameters
 
@@ -205,7 +205,7 @@ keyof `Schemas`
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:427
+Defined in: ridb\_core.d.ts:224
 
 #### Parameters
 
@@ -223,7 +223,7 @@ Defined in: ridb\_core.d.ts:427
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:428
+Defined in: ridb\_core.d.ts:225
 
 #### Parameters
 
@@ -241,7 +241,7 @@ Defined in: ridb\_core.d.ts:428
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:421
+Defined in: ridb\_core.d.ts:218
 
 #### Returns
 
@@ -257,7 +257,7 @@ Defined in: ridb\_core.d.ts:421
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:426
+Defined in: ridb\_core.d.ts:223
 
 #### Parameters
 
@@ -279,7 +279,7 @@ Defined in: ridb\_core.d.ts:426
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`, `options?`): `Promise`\<`BaseStorage`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:403
+Defined in: ridb\_core.d.ts:200
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/BaseStorage.md
+++ b/docs/@trust0/ridb-core/classes/BaseStorage.md
@@ -6,7 +6,7 @@
 
 # Class: BaseStorage\<Schemas\>
 
-Defined in: ridb\_core.d.ts:497
+Defined in: ridb\_core.d.ts:240
 
 ## Extends
 
@@ -14,8 +14,8 @@ Defined in: ridb\_core.d.ts:497
 
 ## Extended by
 
-- [`IndexDB`](IndexDB.md)
 - [`InMemory`](InMemory.md)
+- [`IndexDB`](IndexDB.md)
 
 ## Type Parameters
 
@@ -29,7 +29,7 @@ Defined in: ridb\_core.d.ts:497
 
 > **new BaseStorage**\<`Schemas`\>(`dbName`, `schemas`, `options?`): `BaseStorage`\<`Schemas`\>
 
-Defined in: ridb\_core.d.ts:507
+Defined in: ridb\_core.d.ts:250
 
 #### Parameters
 
@@ -59,7 +59,7 @@ Defined in: ridb\_core.d.ts:507
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:515
+Defined in: ridb\_core.d.ts:258
 
 ***
 
@@ -67,7 +67,7 @@ Defined in: ridb\_core.d.ts:515
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:512
+Defined in: ridb\_core.d.ts:255
 
 ***
 
@@ -75,7 +75,7 @@ Defined in: ridb\_core.d.ts:512
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:514
+Defined in: ridb\_core.d.ts:257
 
 ***
 
@@ -83,7 +83,7 @@ Defined in: ridb\_core.d.ts:514
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:513
+Defined in: ridb\_core.d.ts:256
 
 ## Methods
 
@@ -91,7 +91,7 @@ Defined in: ridb\_core.d.ts:513
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:525
+Defined in: ridb\_core.d.ts:268
 
 #### Returns
 
@@ -103,7 +103,7 @@ Defined in: ridb\_core.d.ts:525
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:517
+Defined in: ridb\_core.d.ts:260
 
 #### Returns
 
@@ -119,7 +119,7 @@ Defined in: ridb\_core.d.ts:517
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:518
+Defined in: ridb\_core.d.ts:261
 
 #### Parameters
 
@@ -149,7 +149,7 @@ keyof `Schemas`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:520
+Defined in: ridb\_core.d.ts:263
 
 #### Parameters
 
@@ -179,7 +179,7 @@ keyof `Schemas`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:519
+Defined in: ridb\_core.d.ts:262
 
 #### Parameters
 
@@ -205,7 +205,7 @@ keyof `Schemas`
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:522
+Defined in: ridb\_core.d.ts:265
 
 #### Parameters
 
@@ -223,7 +223,7 @@ Defined in: ridb\_core.d.ts:522
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:523
+Defined in: ridb\_core.d.ts:266
 
 #### Parameters
 
@@ -241,7 +241,7 @@ Defined in: ridb\_core.d.ts:523
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:516
+Defined in: ridb\_core.d.ts:259
 
 #### Returns
 
@@ -257,7 +257,7 @@ Defined in: ridb\_core.d.ts:516
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:521
+Defined in: ridb\_core.d.ts:264
 
 #### Parameters
 
@@ -279,7 +279,7 @@ Defined in: ridb\_core.d.ts:521
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`, `options?`): `Promise`\<`BaseStorage`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:498
+Defined in: ridb\_core.d.ts:241
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/BaseStorage.md
+++ b/docs/@trust0/ridb-core/classes/BaseStorage.md
@@ -6,7 +6,7 @@
 
 # Class: BaseStorage\<Schemas\>
 
-Defined in: ridb\_core.d.ts:239
+Defined in: ridb\_core.d.ts:497
 
 ## Extends
 
@@ -14,8 +14,8 @@ Defined in: ridb\_core.d.ts:239
 
 ## Extended by
 
-- [`InMemory`](InMemory.md)
 - [`IndexDB`](IndexDB.md)
+- [`InMemory`](InMemory.md)
 
 ## Type Parameters
 
@@ -29,7 +29,7 @@ Defined in: ridb\_core.d.ts:239
 
 > **new BaseStorage**\<`Schemas`\>(`dbName`, `schemas`, `options?`): `BaseStorage`\<`Schemas`\>
 
-Defined in: ridb\_core.d.ts:249
+Defined in: ridb\_core.d.ts:507
 
 #### Parameters
 
@@ -59,7 +59,7 @@ Defined in: ridb\_core.d.ts:249
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:257
+Defined in: ridb\_core.d.ts:515
 
 ***
 
@@ -67,7 +67,7 @@ Defined in: ridb\_core.d.ts:257
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:254
+Defined in: ridb\_core.d.ts:512
 
 ***
 
@@ -75,7 +75,7 @@ Defined in: ridb\_core.d.ts:254
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:256
+Defined in: ridb\_core.d.ts:514
 
 ***
 
@@ -83,7 +83,7 @@ Defined in: ridb\_core.d.ts:256
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:255
+Defined in: ridb\_core.d.ts:513
 
 ## Methods
 
@@ -91,7 +91,7 @@ Defined in: ridb\_core.d.ts:255
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:267
+Defined in: ridb\_core.d.ts:525
 
 #### Returns
 
@@ -103,7 +103,7 @@ Defined in: ridb\_core.d.ts:267
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:259
+Defined in: ridb\_core.d.ts:517
 
 #### Returns
 
@@ -119,7 +119,7 @@ Defined in: ridb\_core.d.ts:259
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:260
+Defined in: ridb\_core.d.ts:518
 
 #### Parameters
 
@@ -149,7 +149,7 @@ keyof `Schemas`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:262
+Defined in: ridb\_core.d.ts:520
 
 #### Parameters
 
@@ -179,7 +179,7 @@ keyof `Schemas`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:261
+Defined in: ridb\_core.d.ts:519
 
 #### Parameters
 
@@ -205,7 +205,7 @@ keyof `Schemas`
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:264
+Defined in: ridb\_core.d.ts:522
 
 #### Parameters
 
@@ -223,7 +223,7 @@ Defined in: ridb\_core.d.ts:264
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:265
+Defined in: ridb\_core.d.ts:523
 
 #### Parameters
 
@@ -241,7 +241,7 @@ Defined in: ridb\_core.d.ts:265
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:258
+Defined in: ridb\_core.d.ts:516
 
 #### Returns
 
@@ -257,7 +257,7 @@ Defined in: ridb\_core.d.ts:258
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:263
+Defined in: ridb\_core.d.ts:521
 
 #### Parameters
 
@@ -279,7 +279,7 @@ Defined in: ridb\_core.d.ts:263
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`, `options?`): `Promise`\<`BaseStorage`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:240
+Defined in: ridb\_core.d.ts:498
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/BaseStorage.md
+++ b/docs/@trust0/ridb-core/classes/BaseStorage.md
@@ -6,7 +6,7 @@
 
 # Class: BaseStorage\<Schemas\>
 
-Defined in: ridb\_core.d.ts:199
+Defined in: ridb\_core.d.ts:239
 
 ## Extends
 
@@ -14,8 +14,8 @@ Defined in: ridb\_core.d.ts:199
 
 ## Extended by
 
-- [`IndexDB`](IndexDB.md)
 - [`InMemory`](InMemory.md)
+- [`IndexDB`](IndexDB.md)
 
 ## Type Parameters
 
@@ -29,7 +29,7 @@ Defined in: ridb\_core.d.ts:199
 
 > **new BaseStorage**\<`Schemas`\>(`dbName`, `schemas`, `options?`): `BaseStorage`\<`Schemas`\>
 
-Defined in: ridb\_core.d.ts:209
+Defined in: ridb\_core.d.ts:249
 
 #### Parameters
 
@@ -59,7 +59,7 @@ Defined in: ridb\_core.d.ts:209
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:217
+Defined in: ridb\_core.d.ts:257
 
 ***
 
@@ -67,7 +67,7 @@ Defined in: ridb\_core.d.ts:217
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:214
+Defined in: ridb\_core.d.ts:254
 
 ***
 
@@ -75,7 +75,7 @@ Defined in: ridb\_core.d.ts:214
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:216
+Defined in: ridb\_core.d.ts:256
 
 ***
 
@@ -83,7 +83,7 @@ Defined in: ridb\_core.d.ts:216
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:215
+Defined in: ridb\_core.d.ts:255
 
 ## Methods
 
@@ -91,7 +91,7 @@ Defined in: ridb\_core.d.ts:215
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:227
+Defined in: ridb\_core.d.ts:267
 
 #### Returns
 
@@ -103,7 +103,7 @@ Defined in: ridb\_core.d.ts:227
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:219
+Defined in: ridb\_core.d.ts:259
 
 #### Returns
 
@@ -119,7 +119,7 @@ Defined in: ridb\_core.d.ts:219
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:220
+Defined in: ridb\_core.d.ts:260
 
 #### Parameters
 
@@ -149,7 +149,7 @@ keyof `Schemas`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:222
+Defined in: ridb\_core.d.ts:262
 
 #### Parameters
 
@@ -179,7 +179,7 @@ keyof `Schemas`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:221
+Defined in: ridb\_core.d.ts:261
 
 #### Parameters
 
@@ -205,7 +205,7 @@ keyof `Schemas`
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:224
+Defined in: ridb\_core.d.ts:264
 
 #### Parameters
 
@@ -223,7 +223,7 @@ Defined in: ridb\_core.d.ts:224
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:225
+Defined in: ridb\_core.d.ts:265
 
 #### Parameters
 
@@ -241,7 +241,7 @@ Defined in: ridb\_core.d.ts:225
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:218
+Defined in: ridb\_core.d.ts:258
 
 #### Returns
 
@@ -257,7 +257,7 @@ Defined in: ridb\_core.d.ts:218
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:223
+Defined in: ridb\_core.d.ts:263
 
 #### Parameters
 
@@ -279,7 +279,7 @@ Defined in: ridb\_core.d.ts:223
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`, `options?`): `Promise`\<`BaseStorage`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:200
+Defined in: ridb\_core.d.ts:240
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/Collection.md
+++ b/docs/@trust0/ridb-core/classes/Collection.md
@@ -6,7 +6,7 @@
 
 # Class: Collection\<T\>
 
-Defined in: ridb\_core.d.ts:265
+Defined in: ridb\_core.d.ts:504
 
 Collection is a class that represents a collection of documents in a database.
 
@@ -34,7 +34,7 @@ A schema type defining the structure of the documents in the collection.
 
 > **count**(`query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:277
+Defined in: ridb\_core.d.ts:516
 
 count all documents in the collection.
 
@@ -60,7 +60,7 @@ A promise that resolves to an array of documents.
 
 > **create**(`document`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\>\>
 
-Defined in: ridb\_core.d.ts:298
+Defined in: ridb\_core.d.ts:537
 
 Creates a new document in the collection.
 
@@ -84,7 +84,7 @@ A promise that resolves to the created document.
 
 > **delete**(`id`): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:305
+Defined in: ridb\_core.d.ts:544
 
 Deletes a document in the collection by its ID.
 
@@ -108,7 +108,7 @@ A promise that resolves when the deletion is complete.
 
 > **find**(`query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\>[]\>
 
-Defined in: ridb\_core.d.ts:271
+Defined in: ridb\_core.d.ts:510
 
 Finds all documents in the collection.
 
@@ -134,7 +134,7 @@ A promise that resolves to an array of documents.
 
 > **findById**(`id`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\>\>
 
-Defined in: ridb\_core.d.ts:284
+Defined in: ridb\_core.d.ts:523
 
 Finds a single document in the collection by its ID.
 
@@ -158,7 +158,7 @@ A promise that resolves to the found document.
 
 > **update**(`document`): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:291
+Defined in: ridb\_core.d.ts:530
 
 Updates a document in the collection by its ID.
 

--- a/docs/@trust0/ridb-core/classes/Collection.md
+++ b/docs/@trust0/ridb-core/classes/Collection.md
@@ -6,7 +6,7 @@
 
 # Class: Collection\<T\>
 
-Defined in: ridb\_core.d.ts:149
+Defined in: ridb\_core.d.ts:265
 
 Collection is a class that represents a collection of documents in a database.
 
@@ -34,7 +34,7 @@ A schema type defining the structure of the documents in the collection.
 
 > **count**(`query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:161
+Defined in: ridb\_core.d.ts:277
 
 count all documents in the collection.
 
@@ -60,7 +60,7 @@ A promise that resolves to an array of documents.
 
 > **create**(`document`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\>\>
 
-Defined in: ridb\_core.d.ts:182
+Defined in: ridb\_core.d.ts:298
 
 Creates a new document in the collection.
 
@@ -84,7 +84,7 @@ A promise that resolves to the created document.
 
 > **delete**(`id`): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:189
+Defined in: ridb\_core.d.ts:305
 
 Deletes a document in the collection by its ID.
 
@@ -108,7 +108,7 @@ A promise that resolves when the deletion is complete.
 
 > **find**(`query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\>[]\>
 
-Defined in: ridb\_core.d.ts:155
+Defined in: ridb\_core.d.ts:271
 
 Finds all documents in the collection.
 
@@ -134,7 +134,7 @@ A promise that resolves to an array of documents.
 
 > **findById**(`id`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\>\>
 
-Defined in: ridb\_core.d.ts:168
+Defined in: ridb\_core.d.ts:284
 
 Finds a single document in the collection by its ID.
 
@@ -158,7 +158,7 @@ A promise that resolves to the found document.
 
 > **update**(`document`): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:175
+Defined in: ridb\_core.d.ts:291
 
 Updates a document in the collection by its ID.
 

--- a/docs/@trust0/ridb-core/classes/Collection.md
+++ b/docs/@trust0/ridb-core/classes/Collection.md
@@ -6,7 +6,7 @@
 
 # Class: Collection\<T\>
 
-Defined in: ridb\_core.d.ts:352
+Defined in: ridb\_core.d.ts:149
 
 Collection is a class that represents a collection of documents in a database.
 
@@ -34,7 +34,7 @@ A schema type defining the structure of the documents in the collection.
 
 > **count**(`query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:364
+Defined in: ridb\_core.d.ts:161
 
 count all documents in the collection.
 
@@ -60,7 +60,7 @@ A promise that resolves to an array of documents.
 
 > **create**(`document`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\>\>
 
-Defined in: ridb\_core.d.ts:385
+Defined in: ridb\_core.d.ts:182
 
 Creates a new document in the collection.
 
@@ -84,7 +84,7 @@ A promise that resolves to the created document.
 
 > **delete**(`id`): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:392
+Defined in: ridb\_core.d.ts:189
 
 Deletes a document in the collection by its ID.
 
@@ -108,7 +108,7 @@ A promise that resolves when the deletion is complete.
 
 > **find**(`query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\>[]\>
 
-Defined in: ridb\_core.d.ts:358
+Defined in: ridb\_core.d.ts:155
 
 Finds all documents in the collection.
 
@@ -134,7 +134,7 @@ A promise that resolves to an array of documents.
 
 > **findById**(`id`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\>\>
 
-Defined in: ridb\_core.d.ts:371
+Defined in: ridb\_core.d.ts:168
 
 Finds a single document in the collection by its ID.
 
@@ -158,7 +158,7 @@ A promise that resolves to the found document.
 
 > **update**(`document`): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:378
+Defined in: ridb\_core.d.ts:175
 
 Updates a document in the collection by its ID.
 

--- a/docs/@trust0/ridb-core/classes/CoreStorage.md
+++ b/docs/@trust0/ridb-core/classes/CoreStorage.md
@@ -6,7 +6,7 @@
 
 # Class: CoreStorage
 
-Defined in: ridb\_core.d.ts:616
+Defined in: ridb\_core.d.ts:195
 
 ## Constructors
 
@@ -24,7 +24,7 @@ Defined in: ridb\_core.d.ts:616
 
 > **getIndexes**(`schema`, `op`): `string`[]
 
-Defined in: ridb\_core.d.ts:624
+Defined in: ridb\_core.d.ts:203
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:624
 
 > **getPrimaryKeyTyped**(`value`): `string` \| `number`
 
-Defined in: ridb\_core.d.ts:623
+Defined in: ridb\_core.d.ts:202
 
 #### Parameters
 
@@ -64,7 +64,7 @@ Defined in: ridb\_core.d.ts:623
 
 > **matchesQuery**(`document`, `query`): `boolean`
 
-Defined in: ridb\_core.d.ts:622
+Defined in: ridb\_core.d.ts:201
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/classes/CoreStorage.md
+++ b/docs/@trust0/ridb-core/classes/CoreStorage.md
@@ -6,7 +6,7 @@
 
 # Class: CoreStorage
 
-Defined in: ridb\_core.d.ts:195
+Defined in: ridb\_core.d.ts:311
 
 ## Constructors
 
@@ -24,7 +24,7 @@ Defined in: ridb\_core.d.ts:195
 
 > **getIndexes**(`schema`, `op`): `string`[]
 
-Defined in: ridb\_core.d.ts:203
+Defined in: ridb\_core.d.ts:319
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:203
 
 > **getPrimaryKeyTyped**(`value`): `string` \| `number`
 
-Defined in: ridb\_core.d.ts:202
+Defined in: ridb\_core.d.ts:318
 
 #### Parameters
 
@@ -64,7 +64,7 @@ Defined in: ridb\_core.d.ts:202
 
 > **matchesQuery**(`document`, `query`): `boolean`
 
-Defined in: ridb\_core.d.ts:201
+Defined in: ridb\_core.d.ts:317
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/classes/CoreStorage.md
+++ b/docs/@trust0/ridb-core/classes/CoreStorage.md
@@ -6,7 +6,7 @@
 
 # Class: CoreStorage
 
-Defined in: ridb\_core.d.ts:311
+Defined in: ridb\_core.d.ts:418
 
 ## Constructors
 
@@ -24,7 +24,7 @@ Defined in: ridb\_core.d.ts:311
 
 > **getIndexes**(`schema`, `op`): `string`[]
 
-Defined in: ridb\_core.d.ts:319
+Defined in: ridb\_core.d.ts:426
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:319
 
 > **getPrimaryKeyTyped**(`value`): `string` \| `number`
 
-Defined in: ridb\_core.d.ts:318
+Defined in: ridb\_core.d.ts:425
 
 #### Parameters
 
@@ -64,7 +64,7 @@ Defined in: ridb\_core.d.ts:318
 
 > **matchesQuery**(`document`, `query`): `boolean`
 
-Defined in: ridb\_core.d.ts:317
+Defined in: ridb\_core.d.ts:424
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/classes/CoreStorage.md
+++ b/docs/@trust0/ridb-core/classes/CoreStorage.md
@@ -6,7 +6,7 @@
 
 # Class: CoreStorage
 
-Defined in: ridb\_core.d.ts:581
+Defined in: ridb\_core.d.ts:616
 
 ## Constructors
 
@@ -24,7 +24,7 @@ Defined in: ridb\_core.d.ts:581
 
 > **getIndexes**(`schema`, `op`): `string`[]
 
-Defined in: ridb\_core.d.ts:589
+Defined in: ridb\_core.d.ts:624
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:589
 
 > **getPrimaryKeyTyped**(`value`): `string` \| `number`
 
-Defined in: ridb\_core.d.ts:588
+Defined in: ridb\_core.d.ts:623
 
 #### Parameters
 
@@ -64,7 +64,7 @@ Defined in: ridb\_core.d.ts:588
 
 > **matchesQuery**(`document`, `query`): `boolean`
 
-Defined in: ridb\_core.d.ts:587
+Defined in: ridb\_core.d.ts:622
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/classes/Database.md
+++ b/docs/@trust0/ridb-core/classes/Database.md
@@ -6,7 +6,7 @@
 
 # Class: Database\<T\>
 
-Defined in: ridb\_core.d.ts:301
+Defined in: ridb\_core.d.ts:559
 
 Represents a database containing collections of documents.
 RIDB extends from this class and is used to expose collections.
@@ -58,7 +58,7 @@ A record of schema types.
 
 > `readonly` **collections**: \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: ridb\_core.d.ts:331
+Defined in: ridb\_core.d.ts:589
 
 The collections in the database.
 
@@ -70,7 +70,7 @@ This is a read-only property where the key is the name of the collection and the
 
 > `readonly` **started**: `boolean`
 
-Defined in: ridb\_core.d.ts:335
+Defined in: ridb\_core.d.ts:593
 
 ## Methods
 
@@ -78,7 +78,7 @@ Defined in: ridb\_core.d.ts:335
 
 > **authenticate**(`password`): `Promise`\<`boolean`\>
 
-Defined in: ridb\_core.d.ts:324
+Defined in: ridb\_core.d.ts:582
 
 #### Parameters
 
@@ -96,7 +96,7 @@ Defined in: ridb\_core.d.ts:324
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:349
+Defined in: ridb\_core.d.ts:607
 
 Closes the database.
 
@@ -112,7 +112,7 @@ A promise that resolves when the database is closed.
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:342
+Defined in: ridb\_core.d.ts:600
 
 Starts the database.
 
@@ -128,7 +128,7 @@ A promise that resolves when the database is started.
 
 > `static` **create**\<`TS`\>(`db_name`, `schemas`, `migrations`, `plugins`, `options`, `password?`, `storage?`): `Promise`\<`Database`\<`TS`\>\>
 
-Defined in: ridb\_core.d.ts:314
+Defined in: ridb\_core.d.ts:572
 
 Creates a new `Database` instance with the provided schemas and storage module.
 

--- a/docs/@trust0/ridb-core/classes/Database.md
+++ b/docs/@trust0/ridb-core/classes/Database.md
@@ -6,7 +6,7 @@
 
 # Class: Database\<T\>
 
-Defined in: ridb\_core.d.ts:658
+Defined in: ridb\_core.d.ts:301
 
 Represents a database containing collections of documents.
 RIDB extends from this class and is used to expose collections.
@@ -58,7 +58,7 @@ A record of schema types.
 
 > `readonly` **collections**: \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: ridb\_core.d.ts:688
+Defined in: ridb\_core.d.ts:331
 
 The collections in the database.
 
@@ -70,7 +70,7 @@ This is a read-only property where the key is the name of the collection and the
 
 > `readonly` **started**: `boolean`
 
-Defined in: ridb\_core.d.ts:692
+Defined in: ridb\_core.d.ts:335
 
 ## Methods
 
@@ -78,7 +78,7 @@ Defined in: ridb\_core.d.ts:692
 
 > **authenticate**(`password`): `Promise`\<`boolean`\>
 
-Defined in: ridb\_core.d.ts:681
+Defined in: ridb\_core.d.ts:324
 
 #### Parameters
 
@@ -96,7 +96,7 @@ Defined in: ridb\_core.d.ts:681
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:706
+Defined in: ridb\_core.d.ts:349
 
 Closes the database.
 
@@ -112,7 +112,7 @@ A promise that resolves when the database is closed.
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:699
+Defined in: ridb\_core.d.ts:342
 
 Starts the database.
 
@@ -128,7 +128,7 @@ A promise that resolves when the database is started.
 
 > `static` **create**\<`TS`\>(`db_name`, `schemas`, `migrations`, `plugins`, `options`, `password?`, `storage?`): `Promise`\<`Database`\<`TS`\>\>
 
-Defined in: ridb\_core.d.ts:671
+Defined in: ridb\_core.d.ts:314
 
 Creates a new `Database` instance with the provided schemas and storage module.
 

--- a/docs/@trust0/ridb-core/classes/Database.md
+++ b/docs/@trust0/ridb-core/classes/Database.md
@@ -6,7 +6,7 @@
 
 # Class: Database\<T\>
 
-Defined in: ridb\_core.d.ts:559
+Defined in: ridb\_core.d.ts:302
 
 Represents a database containing collections of documents.
 RIDB extends from this class and is used to expose collections.
@@ -58,7 +58,7 @@ A record of schema types.
 
 > `readonly` **collections**: \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: ridb\_core.d.ts:589
+Defined in: ridb\_core.d.ts:332
 
 The collections in the database.
 
@@ -70,7 +70,7 @@ This is a read-only property where the key is the name of the collection and the
 
 > `readonly` **started**: `boolean`
 
-Defined in: ridb\_core.d.ts:593
+Defined in: ridb\_core.d.ts:336
 
 ## Methods
 
@@ -78,7 +78,7 @@ Defined in: ridb\_core.d.ts:593
 
 > **authenticate**(`password`): `Promise`\<`boolean`\>
 
-Defined in: ridb\_core.d.ts:582
+Defined in: ridb\_core.d.ts:325
 
 #### Parameters
 
@@ -96,7 +96,7 @@ Defined in: ridb\_core.d.ts:582
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:607
+Defined in: ridb\_core.d.ts:350
 
 Closes the database.
 
@@ -112,7 +112,7 @@ A promise that resolves when the database is closed.
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:600
+Defined in: ridb\_core.d.ts:343
 
 Starts the database.
 
@@ -128,7 +128,7 @@ A promise that resolves when the database is started.
 
 > `static` **create**\<`TS`\>(`db_name`, `schemas`, `migrations`, `plugins`, `options`, `password?`, `storage?`): `Promise`\<`Database`\<`TS`\>\>
 
-Defined in: ridb\_core.d.ts:572
+Defined in: ridb\_core.d.ts:315
 
 Creates a new `Database` instance with the provided schemas and storage module.
 

--- a/docs/@trust0/ridb-core/classes/Database.md
+++ b/docs/@trust0/ridb-core/classes/Database.md
@@ -6,7 +6,7 @@
 
 # Class: Database\<T\>
 
-Defined in: ridb\_core.d.ts:623
+Defined in: ridb\_core.d.ts:658
 
 Represents a database containing collections of documents.
 RIDB extends from this class and is used to expose collections.
@@ -58,7 +58,7 @@ A record of schema types.
 
 > `readonly` **collections**: \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: ridb\_core.d.ts:653
+Defined in: ridb\_core.d.ts:688
 
 The collections in the database.
 
@@ -70,7 +70,7 @@ This is a read-only property where the key is the name of the collection and the
 
 > `readonly` **started**: `boolean`
 
-Defined in: ridb\_core.d.ts:657
+Defined in: ridb\_core.d.ts:692
 
 ## Methods
 
@@ -78,7 +78,7 @@ Defined in: ridb\_core.d.ts:657
 
 > **authenticate**(`password`): `Promise`\<`boolean`\>
 
-Defined in: ridb\_core.d.ts:646
+Defined in: ridb\_core.d.ts:681
 
 #### Parameters
 
@@ -96,7 +96,7 @@ Defined in: ridb\_core.d.ts:646
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:671
+Defined in: ridb\_core.d.ts:706
 
 Closes the database.
 
@@ -112,7 +112,7 @@ A promise that resolves when the database is closed.
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:664
+Defined in: ridb\_core.d.ts:699
 
 Starts the database.
 
@@ -128,7 +128,7 @@ A promise that resolves when the database is started.
 
 > `static` **create**\<`TS`\>(`db_name`, `schemas`, `migrations`, `plugins`, `options`, `password?`, `storage?`): `Promise`\<`Database`\<`TS`\>\>
 
-Defined in: ridb\_core.d.ts:636
+Defined in: ridb\_core.d.ts:671
 
 Creates a new `Database` instance with the provided schemas and storage module.
 

--- a/docs/@trust0/ridb-core/classes/InMemory.md
+++ b/docs/@trust0/ridb-core/classes/InMemory.md
@@ -6,7 +6,7 @@
 
 # Class: InMemory\<T\>
 
-Defined in: ridb\_core.d.ts:440
+Defined in: ridb\_core.d.ts:218
 
 Represents an in-memory storage system extending the base storage functionality.
 
@@ -28,7 +28,7 @@ The schema type.
 
 > **new InMemory**\<`T`\>(`dbName`, `schemas`, `options?`): `InMemory`\<`T`\>
 
-Defined in: ridb\_core.d.ts:507
+Defined in: ridb\_core.d.ts:250
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:507
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:515
+Defined in: ridb\_core.d.ts:258
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: ridb\_core.d.ts:515
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:512
+Defined in: ridb\_core.d.ts:255
 
 #### Inherited from
 
@@ -82,7 +82,7 @@ Defined in: ridb\_core.d.ts:512
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:514
+Defined in: ridb\_core.d.ts:257
 
 #### Inherited from
 
@@ -94,7 +94,7 @@ Defined in: ridb\_core.d.ts:514
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:513
+Defined in: ridb\_core.d.ts:256
 
 #### Inherited from
 
@@ -106,7 +106,7 @@ Defined in: ridb\_core.d.ts:513
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:525
+Defined in: ridb\_core.d.ts:268
 
 #### Returns
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:525
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:517
+Defined in: ridb\_core.d.ts:260
 
 #### Returns
 
@@ -138,7 +138,7 @@ Defined in: ridb\_core.d.ts:517
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:518
+Defined in: ridb\_core.d.ts:261
 
 #### Parameters
 
@@ -168,7 +168,7 @@ keyof `T`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:520
+Defined in: ridb\_core.d.ts:263
 
 #### Parameters
 
@@ -198,7 +198,7 @@ keyof `T`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:519
+Defined in: ridb\_core.d.ts:262
 
 #### Parameters
 
@@ -224,7 +224,7 @@ keyof `T`
 
 > **free**(): `void`
 
-Defined in: ridb\_core.d.ts:444
+Defined in: ridb\_core.d.ts:222
 
 Frees the resources used by the in-memory storage.
 
@@ -238,7 +238,7 @@ Frees the resources used by the in-memory storage.
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:522
+Defined in: ridb\_core.d.ts:265
 
 #### Parameters
 
@@ -260,7 +260,7 @@ Defined in: ridb\_core.d.ts:522
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:523
+Defined in: ridb\_core.d.ts:266
 
 #### Parameters
 
@@ -282,7 +282,7 @@ Defined in: ridb\_core.d.ts:523
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:516
+Defined in: ridb\_core.d.ts:259
 
 #### Returns
 
@@ -298,7 +298,7 @@ Defined in: ridb\_core.d.ts:516
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:521
+Defined in: ridb\_core.d.ts:264
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:521
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`): `Promise`\<`InMemory`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:446
+Defined in: ridb\_core.d.ts:224
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/InMemory.md
+++ b/docs/@trust0/ridb-core/classes/InMemory.md
@@ -6,7 +6,7 @@
 
 # Class: InMemory\<T\>
 
-Defined in: ridb\_core.d.ts:563
+Defined in: ridb\_core.d.ts:435
 
 Represents an in-memory storage system extending the base storage functionality.
 
@@ -28,7 +28,7 @@ The schema type.
 
 > **new InMemory**\<`T`\>(`dbName`, `schemas`, `options?`): `InMemory`\<`T`\>
 
-Defined in: ridb\_core.d.ts:209
+Defined in: ridb\_core.d.ts:249
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:209
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:217
+Defined in: ridb\_core.d.ts:257
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: ridb\_core.d.ts:217
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:214
+Defined in: ridb\_core.d.ts:254
 
 #### Inherited from
 
@@ -82,7 +82,7 @@ Defined in: ridb\_core.d.ts:214
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:216
+Defined in: ridb\_core.d.ts:256
 
 #### Inherited from
 
@@ -94,7 +94,7 @@ Defined in: ridb\_core.d.ts:216
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:215
+Defined in: ridb\_core.d.ts:255
 
 #### Inherited from
 
@@ -106,7 +106,7 @@ Defined in: ridb\_core.d.ts:215
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:227
+Defined in: ridb\_core.d.ts:267
 
 #### Returns
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:227
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:219
+Defined in: ridb\_core.d.ts:259
 
 #### Returns
 
@@ -138,7 +138,7 @@ Defined in: ridb\_core.d.ts:219
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:220
+Defined in: ridb\_core.d.ts:260
 
 #### Parameters
 
@@ -168,7 +168,7 @@ keyof `T`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:222
+Defined in: ridb\_core.d.ts:262
 
 #### Parameters
 
@@ -198,7 +198,7 @@ keyof `T`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:221
+Defined in: ridb\_core.d.ts:261
 
 #### Parameters
 
@@ -224,7 +224,7 @@ keyof `T`
 
 > **free**(): `void`
 
-Defined in: ridb\_core.d.ts:567
+Defined in: ridb\_core.d.ts:439
 
 Frees the resources used by the in-memory storage.
 
@@ -238,7 +238,7 @@ Frees the resources used by the in-memory storage.
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:224
+Defined in: ridb\_core.d.ts:264
 
 #### Parameters
 
@@ -260,7 +260,7 @@ Defined in: ridb\_core.d.ts:224
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:225
+Defined in: ridb\_core.d.ts:265
 
 #### Parameters
 
@@ -282,7 +282,7 @@ Defined in: ridb\_core.d.ts:225
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:218
+Defined in: ridb\_core.d.ts:258
 
 #### Returns
 
@@ -298,7 +298,7 @@ Defined in: ridb\_core.d.ts:218
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:223
+Defined in: ridb\_core.d.ts:263
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:223
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`): `Promise`\<`InMemory`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:569
+Defined in: ridb\_core.d.ts:441
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/InMemory.md
+++ b/docs/@trust0/ridb-core/classes/InMemory.md
@@ -28,7 +28,7 @@ The schema type.
 
 > **new InMemory**\<`T`\>(`dbName`, `schemas`, `options?`): `InMemory`\<`T`\>
 
-Defined in: ridb\_core.d.ts:412
+Defined in: ridb\_core.d.ts:209
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:412
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:420
+Defined in: ridb\_core.d.ts:217
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: ridb\_core.d.ts:420
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:417
+Defined in: ridb\_core.d.ts:214
 
 #### Inherited from
 
@@ -82,7 +82,7 @@ Defined in: ridb\_core.d.ts:417
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:419
+Defined in: ridb\_core.d.ts:216
 
 #### Inherited from
 
@@ -94,7 +94,7 @@ Defined in: ridb\_core.d.ts:419
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:418
+Defined in: ridb\_core.d.ts:215
 
 #### Inherited from
 
@@ -106,7 +106,7 @@ Defined in: ridb\_core.d.ts:418
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:430
+Defined in: ridb\_core.d.ts:227
 
 #### Returns
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:430
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:422
+Defined in: ridb\_core.d.ts:219
 
 #### Returns
 
@@ -138,7 +138,7 @@ Defined in: ridb\_core.d.ts:422
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:423
+Defined in: ridb\_core.d.ts:220
 
 #### Parameters
 
@@ -168,7 +168,7 @@ keyof `T`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:425
+Defined in: ridb\_core.d.ts:222
 
 #### Parameters
 
@@ -198,7 +198,7 @@ keyof `T`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:424
+Defined in: ridb\_core.d.ts:221
 
 #### Parameters
 
@@ -238,7 +238,7 @@ Frees the resources used by the in-memory storage.
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:427
+Defined in: ridb\_core.d.ts:224
 
 #### Parameters
 
@@ -260,7 +260,7 @@ Defined in: ridb\_core.d.ts:427
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:428
+Defined in: ridb\_core.d.ts:225
 
 #### Parameters
 
@@ -282,7 +282,7 @@ Defined in: ridb\_core.d.ts:428
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:421
+Defined in: ridb\_core.d.ts:218
 
 #### Returns
 
@@ -298,7 +298,7 @@ Defined in: ridb\_core.d.ts:421
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:426
+Defined in: ridb\_core.d.ts:223
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/classes/InMemory.md
+++ b/docs/@trust0/ridb-core/classes/InMemory.md
@@ -6,7 +6,7 @@
 
 # Class: InMemory\<T\>
 
-Defined in: ridb\_core.d.ts:435
+Defined in: ridb\_core.d.ts:440
 
 Represents an in-memory storage system extending the base storage functionality.
 
@@ -28,7 +28,7 @@ The schema type.
 
 > **new InMemory**\<`T`\>(`dbName`, `schemas`, `options?`): `InMemory`\<`T`\>
 
-Defined in: ridb\_core.d.ts:249
+Defined in: ridb\_core.d.ts:507
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:249
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:257
+Defined in: ridb\_core.d.ts:515
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: ridb\_core.d.ts:257
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:254
+Defined in: ridb\_core.d.ts:512
 
 #### Inherited from
 
@@ -82,7 +82,7 @@ Defined in: ridb\_core.d.ts:254
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:256
+Defined in: ridb\_core.d.ts:514
 
 #### Inherited from
 
@@ -94,7 +94,7 @@ Defined in: ridb\_core.d.ts:256
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:255
+Defined in: ridb\_core.d.ts:513
 
 #### Inherited from
 
@@ -106,7 +106,7 @@ Defined in: ridb\_core.d.ts:255
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:267
+Defined in: ridb\_core.d.ts:525
 
 #### Returns
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:267
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:259
+Defined in: ridb\_core.d.ts:517
 
 #### Returns
 
@@ -138,7 +138,7 @@ Defined in: ridb\_core.d.ts:259
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:260
+Defined in: ridb\_core.d.ts:518
 
 #### Parameters
 
@@ -168,7 +168,7 @@ keyof `T`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:262
+Defined in: ridb\_core.d.ts:520
 
 #### Parameters
 
@@ -198,7 +198,7 @@ keyof `T`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:261
+Defined in: ridb\_core.d.ts:519
 
 #### Parameters
 
@@ -224,7 +224,7 @@ keyof `T`
 
 > **free**(): `void`
 
-Defined in: ridb\_core.d.ts:439
+Defined in: ridb\_core.d.ts:444
 
 Frees the resources used by the in-memory storage.
 
@@ -238,7 +238,7 @@ Frees the resources used by the in-memory storage.
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:264
+Defined in: ridb\_core.d.ts:522
 
 #### Parameters
 
@@ -260,7 +260,7 @@ Defined in: ridb\_core.d.ts:264
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:265
+Defined in: ridb\_core.d.ts:523
 
 #### Parameters
 
@@ -282,7 +282,7 @@ Defined in: ridb\_core.d.ts:265
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:258
+Defined in: ridb\_core.d.ts:516
 
 #### Returns
 
@@ -298,7 +298,7 @@ Defined in: ridb\_core.d.ts:258
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:263
+Defined in: ridb\_core.d.ts:521
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:263
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`): `Promise`\<`InMemory`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:441
+Defined in: ridb\_core.d.ts:446
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/IndexDB.md
+++ b/docs/@trust0/ridb-core/classes/IndexDB.md
@@ -6,7 +6,7 @@
 
 # Class: IndexDB\<T\>
 
-Defined in: ridb\_core.d.ts:742
+Defined in: ridb\_core.d.ts:174
 
 Represents an IndexDB storage system extending the base storage functionality.
 
@@ -28,7 +28,7 @@ The schema type.
 
 > **new IndexDB**\<`T`\>(`dbName`, `schemas`, `options?`): `IndexDB`\<`T`\>
 
-Defined in: ridb\_core.d.ts:249
+Defined in: ridb\_core.d.ts:507
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:249
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:257
+Defined in: ridb\_core.d.ts:515
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: ridb\_core.d.ts:257
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:254
+Defined in: ridb\_core.d.ts:512
 
 #### Inherited from
 
@@ -82,7 +82,7 @@ Defined in: ridb\_core.d.ts:254
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:256
+Defined in: ridb\_core.d.ts:514
 
 #### Inherited from
 
@@ -94,7 +94,7 @@ Defined in: ridb\_core.d.ts:256
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:255
+Defined in: ridb\_core.d.ts:513
 
 #### Inherited from
 
@@ -106,7 +106,7 @@ Defined in: ridb\_core.d.ts:255
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:267
+Defined in: ridb\_core.d.ts:525
 
 #### Returns
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:267
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:259
+Defined in: ridb\_core.d.ts:517
 
 #### Returns
 
@@ -138,7 +138,7 @@ Defined in: ridb\_core.d.ts:259
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:260
+Defined in: ridb\_core.d.ts:518
 
 #### Parameters
 
@@ -168,7 +168,7 @@ keyof `T`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:262
+Defined in: ridb\_core.d.ts:520
 
 #### Parameters
 
@@ -198,7 +198,7 @@ keyof `T`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:261
+Defined in: ridb\_core.d.ts:519
 
 #### Parameters
 
@@ -224,7 +224,7 @@ keyof `T`
 
 > **free**(): `void`
 
-Defined in: ridb\_core.d.ts:746
+Defined in: ridb\_core.d.ts:178
 
 Frees the resources used by the in-memory storage.
 
@@ -238,7 +238,7 @@ Frees the resources used by the in-memory storage.
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:264
+Defined in: ridb\_core.d.ts:522
 
 #### Parameters
 
@@ -260,7 +260,7 @@ Defined in: ridb\_core.d.ts:264
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:265
+Defined in: ridb\_core.d.ts:523
 
 #### Parameters
 
@@ -282,7 +282,7 @@ Defined in: ridb\_core.d.ts:265
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:258
+Defined in: ridb\_core.d.ts:516
 
 #### Returns
 
@@ -298,7 +298,7 @@ Defined in: ridb\_core.d.ts:258
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:263
+Defined in: ridb\_core.d.ts:521
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:263
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`): `Promise`\<`IndexDB`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:748
+Defined in: ridb\_core.d.ts:180
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/IndexDB.md
+++ b/docs/@trust0/ridb-core/classes/IndexDB.md
@@ -6,7 +6,7 @@
 
 # Class: IndexDB\<T\>
 
-Defined in: ridb\_core.d.ts:440
+Defined in: ridb\_core.d.ts:237
 
 Represents an IndexDB storage system extending the base storage functionality.
 
@@ -28,7 +28,7 @@ The schema type.
 
 > **new IndexDB**\<`T`\>(`dbName`, `schemas`, `options?`): `IndexDB`\<`T`\>
 
-Defined in: ridb\_core.d.ts:412
+Defined in: ridb\_core.d.ts:209
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:412
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:420
+Defined in: ridb\_core.d.ts:217
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: ridb\_core.d.ts:420
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:417
+Defined in: ridb\_core.d.ts:214
 
 #### Inherited from
 
@@ -82,7 +82,7 @@ Defined in: ridb\_core.d.ts:417
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:419
+Defined in: ridb\_core.d.ts:216
 
 #### Inherited from
 
@@ -94,7 +94,7 @@ Defined in: ridb\_core.d.ts:419
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:418
+Defined in: ridb\_core.d.ts:215
 
 #### Inherited from
 
@@ -106,7 +106,7 @@ Defined in: ridb\_core.d.ts:418
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:430
+Defined in: ridb\_core.d.ts:227
 
 #### Returns
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:430
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:422
+Defined in: ridb\_core.d.ts:219
 
 #### Returns
 
@@ -138,7 +138,7 @@ Defined in: ridb\_core.d.ts:422
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:423
+Defined in: ridb\_core.d.ts:220
 
 #### Parameters
 
@@ -168,7 +168,7 @@ keyof `T`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:425
+Defined in: ridb\_core.d.ts:222
 
 #### Parameters
 
@@ -198,7 +198,7 @@ keyof `T`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:424
+Defined in: ridb\_core.d.ts:221
 
 #### Parameters
 
@@ -224,7 +224,7 @@ keyof `T`
 
 > **free**(): `void`
 
-Defined in: ridb\_core.d.ts:444
+Defined in: ridb\_core.d.ts:241
 
 Frees the resources used by the in-memory storage.
 
@@ -238,7 +238,7 @@ Frees the resources used by the in-memory storage.
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:427
+Defined in: ridb\_core.d.ts:224
 
 #### Parameters
 
@@ -260,7 +260,7 @@ Defined in: ridb\_core.d.ts:427
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:428
+Defined in: ridb\_core.d.ts:225
 
 #### Parameters
 
@@ -282,7 +282,7 @@ Defined in: ridb\_core.d.ts:428
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:421
+Defined in: ridb\_core.d.ts:218
 
 #### Returns
 
@@ -298,7 +298,7 @@ Defined in: ridb\_core.d.ts:421
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:426
+Defined in: ridb\_core.d.ts:223
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:426
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`): `Promise`\<`IndexDB`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:446
+Defined in: ridb\_core.d.ts:243
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/IndexDB.md
+++ b/docs/@trust0/ridb-core/classes/IndexDB.md
@@ -6,7 +6,7 @@
 
 # Class: IndexDB\<T\>
 
-Defined in: ridb\_core.d.ts:237
+Defined in: ridb\_core.d.ts:742
 
 Represents an IndexDB storage system extending the base storage functionality.
 
@@ -28,7 +28,7 @@ The schema type.
 
 > **new IndexDB**\<`T`\>(`dbName`, `schemas`, `options?`): `IndexDB`\<`T`\>
 
-Defined in: ridb\_core.d.ts:209
+Defined in: ridb\_core.d.ts:249
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:209
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:217
+Defined in: ridb\_core.d.ts:257
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: ridb\_core.d.ts:217
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:214
+Defined in: ridb\_core.d.ts:254
 
 #### Inherited from
 
@@ -82,7 +82,7 @@ Defined in: ridb\_core.d.ts:214
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:216
+Defined in: ridb\_core.d.ts:256
 
 #### Inherited from
 
@@ -94,7 +94,7 @@ Defined in: ridb\_core.d.ts:216
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:215
+Defined in: ridb\_core.d.ts:255
 
 #### Inherited from
 
@@ -106,7 +106,7 @@ Defined in: ridb\_core.d.ts:215
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:227
+Defined in: ridb\_core.d.ts:267
 
 #### Returns
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:227
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:219
+Defined in: ridb\_core.d.ts:259
 
 #### Returns
 
@@ -138,7 +138,7 @@ Defined in: ridb\_core.d.ts:219
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:220
+Defined in: ridb\_core.d.ts:260
 
 #### Parameters
 
@@ -168,7 +168,7 @@ keyof `T`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:222
+Defined in: ridb\_core.d.ts:262
 
 #### Parameters
 
@@ -198,7 +198,7 @@ keyof `T`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:221
+Defined in: ridb\_core.d.ts:261
 
 #### Parameters
 
@@ -224,7 +224,7 @@ keyof `T`
 
 > **free**(): `void`
 
-Defined in: ridb\_core.d.ts:241
+Defined in: ridb\_core.d.ts:746
 
 Frees the resources used by the in-memory storage.
 
@@ -238,7 +238,7 @@ Frees the resources used by the in-memory storage.
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:224
+Defined in: ridb\_core.d.ts:264
 
 #### Parameters
 
@@ -260,7 +260,7 @@ Defined in: ridb\_core.d.ts:224
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:225
+Defined in: ridb\_core.d.ts:265
 
 #### Parameters
 
@@ -282,7 +282,7 @@ Defined in: ridb\_core.d.ts:225
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:218
+Defined in: ridb\_core.d.ts:258
 
 #### Returns
 
@@ -298,7 +298,7 @@ Defined in: ridb\_core.d.ts:218
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:223
+Defined in: ridb\_core.d.ts:263
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:223
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`): `Promise`\<`IndexDB`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:243
+Defined in: ridb\_core.d.ts:748
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/IndexDB.md
+++ b/docs/@trust0/ridb-core/classes/IndexDB.md
@@ -6,7 +6,7 @@
 
 # Class: IndexDB\<T\>
 
-Defined in: ridb\_core.d.ts:174
+Defined in: ridb\_core.d.ts:400
 
 Represents an IndexDB storage system extending the base storage functionality.
 
@@ -28,7 +28,7 @@ The schema type.
 
 > **new IndexDB**\<`T`\>(`dbName`, `schemas`, `options?`): `IndexDB`\<`T`\>
 
-Defined in: ridb\_core.d.ts:507
+Defined in: ridb\_core.d.ts:250
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:507
 
 > `readonly` **core**: [`CoreStorage`](CoreStorage.md)
 
-Defined in: ridb\_core.d.ts:515
+Defined in: ridb\_core.d.ts:258
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: ridb\_core.d.ts:515
 
 > `readonly` **dbName**: `string`
 
-Defined in: ridb\_core.d.ts:512
+Defined in: ridb\_core.d.ts:255
 
 #### Inherited from
 
@@ -82,7 +82,7 @@ Defined in: ridb\_core.d.ts:512
 
 > `readonly` **options**: [`BaseStorageOptions`](../type-aliases/BaseStorageOptions.md)
 
-Defined in: ridb\_core.d.ts:514
+Defined in: ridb\_core.d.ts:257
 
 #### Inherited from
 
@@ -94,7 +94,7 @@ Defined in: ridb\_core.d.ts:514
 
 > `readonly` **schemas**: `Record`\<keyof `Schemas`, [`Schema`](Schema.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:513
+Defined in: ridb\_core.d.ts:256
 
 #### Inherited from
 
@@ -106,7 +106,7 @@ Defined in: ridb\_core.d.ts:513
 
 > **addIndexSchemas**(): `null`
 
-Defined in: ridb\_core.d.ts:525
+Defined in: ridb\_core.d.ts:268
 
 #### Returns
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:525
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:517
+Defined in: ridb\_core.d.ts:260
 
 #### Returns
 
@@ -138,7 +138,7 @@ Defined in: ridb\_core.d.ts:517
 
 > **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:518
+Defined in: ridb\_core.d.ts:261
 
 #### Parameters
 
@@ -168,7 +168,7 @@ keyof `T`
 
 > **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:520
+Defined in: ridb\_core.d.ts:263
 
 #### Parameters
 
@@ -198,7 +198,7 @@ keyof `T`
 
 > **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:519
+Defined in: ridb\_core.d.ts:262
 
 #### Parameters
 
@@ -224,7 +224,7 @@ keyof `T`
 
 > **free**(): `void`
 
-Defined in: ridb\_core.d.ts:178
+Defined in: ridb\_core.d.ts:404
 
 Frees the resources used by the in-memory storage.
 
@@ -238,7 +238,7 @@ Frees the resources used by the in-memory storage.
 
 > **getOption**(`name`): `undefined` \| `string` \| `number` \| `boolean`
 
-Defined in: ridb\_core.d.ts:522
+Defined in: ridb\_core.d.ts:265
 
 #### Parameters
 
@@ -260,7 +260,7 @@ Defined in: ridb\_core.d.ts:522
 
 > **getSchema**(`name`): [`Schema`](Schema.md)\<`any`\>
 
-Defined in: ridb\_core.d.ts:523
+Defined in: ridb\_core.d.ts:266
 
 #### Parameters
 
@@ -282,7 +282,7 @@ Defined in: ridb\_core.d.ts:523
 
 > **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:516
+Defined in: ridb\_core.d.ts:259
 
 #### Returns
 
@@ -298,7 +298,7 @@ Defined in: ridb\_core.d.ts:516
 
 > **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`T`\[keyof `T`\]\>\>
 
-Defined in: ridb\_core.d.ts:521
+Defined in: ridb\_core.d.ts:264
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:521
 
 > `static` **create**\<`SchemasCreate`\>(`dbName`, `schemas`): `Promise`\<`IndexDB`\<`SchemasCreate`\>\>
 
-Defined in: ridb\_core.d.ts:180
+Defined in: ridb\_core.d.ts:406
 
 #### Type Parameters
 

--- a/docs/@trust0/ridb-core/classes/Property.md
+++ b/docs/@trust0/ridb-core/classes/Property.md
@@ -6,7 +6,7 @@
 
 # Class: Property
 
-Defined in: ridb\_core.d.ts:612
+Defined in: ridb\_core.d.ts:79
 
 Represents a property within a schema, including various constraints and nested properties.
 
@@ -26,7 +26,7 @@ Represents a property within a schema, including various constraints and nested 
 
 > `readonly` `optional` **default**: `any`
 
-Defined in: ridb\_core.d.ts:661
+Defined in: ridb\_core.d.ts:128
 
 An optional default value for the property.
 
@@ -36,7 +36,7 @@ An optional default value for the property.
 
 > `readonly` `optional` **items**: `Property`
 
-Defined in: ridb\_core.d.ts:631
+Defined in: ridb\_core.d.ts:98
 
 An optional array of nested properties for array-type properties.
 
@@ -46,7 +46,7 @@ An optional array of nested properties for array-type properties.
 
 > `readonly` `optional` **maxItems**: `number`
 
-Defined in: ridb\_core.d.ts:636
+Defined in: ridb\_core.d.ts:103
 
 The maximum number of items for array-type properties, if applicable.
 
@@ -56,7 +56,7 @@ The maximum number of items for array-type properties, if applicable.
 
 > `readonly` `optional` **maxLength**: `number`
 
-Defined in: ridb\_core.d.ts:646
+Defined in: ridb\_core.d.ts:113
 
 The maximum length for string-type properties, if applicable.
 
@@ -66,7 +66,7 @@ The maximum length for string-type properties, if applicable.
 
 > `readonly` `optional` **minItems**: `number`
 
-Defined in: ridb\_core.d.ts:641
+Defined in: ridb\_core.d.ts:108
 
 The minimum number of items for array-type properties, if applicable.
 
@@ -76,7 +76,7 @@ The minimum number of items for array-type properties, if applicable.
 
 > `readonly` `optional` **minLength**: `number`
 
-Defined in: ridb\_core.d.ts:651
+Defined in: ridb\_core.d.ts:118
 
 The minimum length for string-type properties, if applicable.
 
@@ -86,7 +86,7 @@ The minimum length for string-type properties, if applicable.
 
 > `readonly` `optional` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:626
+Defined in: ridb\_core.d.ts:93
 
 The primary key of the property, if applicable.
 
@@ -96,7 +96,7 @@ The primary key of the property, if applicable.
 
 > `readonly` `optional` **properties**: `object`
 
-Defined in: ridb\_core.d.ts:666
+Defined in: ridb\_core.d.ts:133
 
 An optional map of nested properties for object-type properties.
 
@@ -110,7 +110,7 @@ An optional map of nested properties for object-type properties.
 
 > `readonly` `optional` **required**: `boolean`
 
-Defined in: ridb\_core.d.ts:656
+Defined in: ridb\_core.d.ts:123
 
 An optional array of required fields for object-type properties.
 
@@ -120,7 +120,7 @@ An optional array of required fields for object-type properties.
 
 > `readonly` **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:616
+Defined in: ridb\_core.d.ts:83
 
 The type of the property.
 
@@ -130,6 +130,6 @@ The type of the property.
 
 > `readonly` `optional` **version**: `number`
 
-Defined in: ridb\_core.d.ts:621
+Defined in: ridb\_core.d.ts:88
 
 The version of the property, if applicable.

--- a/docs/@trust0/ridb-core/classes/Property.md
+++ b/docs/@trust0/ridb-core/classes/Property.md
@@ -6,7 +6,7 @@
 
 # Class: Property
 
-Defined in: ridb\_core.d.ts:79
+Defined in: ridb\_core.d.ts:589
 
 Represents a property within a schema, including various constraints and nested properties.
 
@@ -26,7 +26,7 @@ Represents a property within a schema, including various constraints and nested 
 
 > `readonly` `optional` **default**: `any`
 
-Defined in: ridb\_core.d.ts:128
+Defined in: ridb\_core.d.ts:638
 
 An optional default value for the property.
 
@@ -36,7 +36,7 @@ An optional default value for the property.
 
 > `readonly` `optional` **items**: `Property`
 
-Defined in: ridb\_core.d.ts:98
+Defined in: ridb\_core.d.ts:608
 
 An optional array of nested properties for array-type properties.
 
@@ -46,7 +46,7 @@ An optional array of nested properties for array-type properties.
 
 > `readonly` `optional` **maxItems**: `number`
 
-Defined in: ridb\_core.d.ts:103
+Defined in: ridb\_core.d.ts:613
 
 The maximum number of items for array-type properties, if applicable.
 
@@ -56,7 +56,7 @@ The maximum number of items for array-type properties, if applicable.
 
 > `readonly` `optional` **maxLength**: `number`
 
-Defined in: ridb\_core.d.ts:113
+Defined in: ridb\_core.d.ts:623
 
 The maximum length for string-type properties, if applicable.
 
@@ -66,7 +66,7 @@ The maximum length for string-type properties, if applicable.
 
 > `readonly` `optional` **minItems**: `number`
 
-Defined in: ridb\_core.d.ts:108
+Defined in: ridb\_core.d.ts:618
 
 The minimum number of items for array-type properties, if applicable.
 
@@ -76,7 +76,7 @@ The minimum number of items for array-type properties, if applicable.
 
 > `readonly` `optional` **minLength**: `number`
 
-Defined in: ridb\_core.d.ts:118
+Defined in: ridb\_core.d.ts:628
 
 The minimum length for string-type properties, if applicable.
 
@@ -86,7 +86,7 @@ The minimum length for string-type properties, if applicable.
 
 > `readonly` `optional` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:93
+Defined in: ridb\_core.d.ts:603
 
 The primary key of the property, if applicable.
 
@@ -96,7 +96,7 @@ The primary key of the property, if applicable.
 
 > `readonly` `optional` **properties**: `object`
 
-Defined in: ridb\_core.d.ts:133
+Defined in: ridb\_core.d.ts:643
 
 An optional map of nested properties for object-type properties.
 
@@ -110,7 +110,7 @@ An optional map of nested properties for object-type properties.
 
 > `readonly` `optional` **required**: `boolean`
 
-Defined in: ridb\_core.d.ts:123
+Defined in: ridb\_core.d.ts:633
 
 An optional array of required fields for object-type properties.
 
@@ -120,7 +120,7 @@ An optional array of required fields for object-type properties.
 
 > `readonly` **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:83
+Defined in: ridb\_core.d.ts:593
 
 The type of the property.
 
@@ -130,6 +130,6 @@ The type of the property.
 
 > `readonly` `optional` **version**: `number`
 
-Defined in: ridb\_core.d.ts:88
+Defined in: ridb\_core.d.ts:598
 
 The version of the property, if applicable.

--- a/docs/@trust0/ridb-core/classes/Property.md
+++ b/docs/@trust0/ridb-core/classes/Property.md
@@ -6,7 +6,7 @@
 
 # Class: Property
 
-Defined in: ridb\_core.d.ts:497
+Defined in: ridb\_core.d.ts:294
 
 Represents a property within a schema, including various constraints and nested properties.
 
@@ -26,7 +26,7 @@ Represents a property within a schema, including various constraints and nested 
 
 > `readonly` `optional` **default**: `any`
 
-Defined in: ridb\_core.d.ts:546
+Defined in: ridb\_core.d.ts:343
 
 An optional default value for the property.
 
@@ -36,7 +36,7 @@ An optional default value for the property.
 
 > `readonly` `optional` **items**: `Property`
 
-Defined in: ridb\_core.d.ts:516
+Defined in: ridb\_core.d.ts:313
 
 An optional array of nested properties for array-type properties.
 
@@ -46,7 +46,7 @@ An optional array of nested properties for array-type properties.
 
 > `readonly` `optional` **maxItems**: `number`
 
-Defined in: ridb\_core.d.ts:521
+Defined in: ridb\_core.d.ts:318
 
 The maximum number of items for array-type properties, if applicable.
 
@@ -56,7 +56,7 @@ The maximum number of items for array-type properties, if applicable.
 
 > `readonly` `optional` **maxLength**: `number`
 
-Defined in: ridb\_core.d.ts:531
+Defined in: ridb\_core.d.ts:328
 
 The maximum length for string-type properties, if applicable.
 
@@ -66,7 +66,7 @@ The maximum length for string-type properties, if applicable.
 
 > `readonly` `optional` **minItems**: `number`
 
-Defined in: ridb\_core.d.ts:526
+Defined in: ridb\_core.d.ts:323
 
 The minimum number of items for array-type properties, if applicable.
 
@@ -76,7 +76,7 @@ The minimum number of items for array-type properties, if applicable.
 
 > `readonly` `optional` **minLength**: `number`
 
-Defined in: ridb\_core.d.ts:536
+Defined in: ridb\_core.d.ts:333
 
 The minimum length for string-type properties, if applicable.
 
@@ -86,7 +86,7 @@ The minimum length for string-type properties, if applicable.
 
 > `readonly` `optional` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:511
+Defined in: ridb\_core.d.ts:308
 
 The primary key of the property, if applicable.
 
@@ -96,7 +96,7 @@ The primary key of the property, if applicable.
 
 > `readonly` `optional` **properties**: `object`
 
-Defined in: ridb\_core.d.ts:551
+Defined in: ridb\_core.d.ts:348
 
 An optional map of nested properties for object-type properties.
 
@@ -110,7 +110,7 @@ An optional map of nested properties for object-type properties.
 
 > `readonly` `optional` **required**: `boolean`
 
-Defined in: ridb\_core.d.ts:541
+Defined in: ridb\_core.d.ts:338
 
 An optional array of required fields for object-type properties.
 
@@ -120,7 +120,7 @@ An optional array of required fields for object-type properties.
 
 > `readonly` **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:501
+Defined in: ridb\_core.d.ts:298
 
 The type of the property.
 
@@ -130,6 +130,6 @@ The type of the property.
 
 > `readonly` `optional` **version**: `number`
 
-Defined in: ridb\_core.d.ts:506
+Defined in: ridb\_core.d.ts:303
 
 The version of the property, if applicable.

--- a/docs/@trust0/ridb-core/classes/Property.md
+++ b/docs/@trust0/ridb-core/classes/Property.md
@@ -6,7 +6,7 @@
 
 # Class: Property
 
-Defined in: ridb\_core.d.ts:294
+Defined in: ridb\_core.d.ts:612
 
 Represents a property within a schema, including various constraints and nested properties.
 
@@ -26,7 +26,7 @@ Represents a property within a schema, including various constraints and nested 
 
 > `readonly` `optional` **default**: `any`
 
-Defined in: ridb\_core.d.ts:343
+Defined in: ridb\_core.d.ts:661
 
 An optional default value for the property.
 
@@ -36,7 +36,7 @@ An optional default value for the property.
 
 > `readonly` `optional` **items**: `Property`
 
-Defined in: ridb\_core.d.ts:313
+Defined in: ridb\_core.d.ts:631
 
 An optional array of nested properties for array-type properties.
 
@@ -46,7 +46,7 @@ An optional array of nested properties for array-type properties.
 
 > `readonly` `optional` **maxItems**: `number`
 
-Defined in: ridb\_core.d.ts:318
+Defined in: ridb\_core.d.ts:636
 
 The maximum number of items for array-type properties, if applicable.
 
@@ -56,7 +56,7 @@ The maximum number of items for array-type properties, if applicable.
 
 > `readonly` `optional` **maxLength**: `number`
 
-Defined in: ridb\_core.d.ts:328
+Defined in: ridb\_core.d.ts:646
 
 The maximum length for string-type properties, if applicable.
 
@@ -66,7 +66,7 @@ The maximum length for string-type properties, if applicable.
 
 > `readonly` `optional` **minItems**: `number`
 
-Defined in: ridb\_core.d.ts:323
+Defined in: ridb\_core.d.ts:641
 
 The minimum number of items for array-type properties, if applicable.
 
@@ -76,7 +76,7 @@ The minimum number of items for array-type properties, if applicable.
 
 > `readonly` `optional` **minLength**: `number`
 
-Defined in: ridb\_core.d.ts:333
+Defined in: ridb\_core.d.ts:651
 
 The minimum length for string-type properties, if applicable.
 
@@ -86,7 +86,7 @@ The minimum length for string-type properties, if applicable.
 
 > `readonly` `optional` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:308
+Defined in: ridb\_core.d.ts:626
 
 The primary key of the property, if applicable.
 
@@ -96,7 +96,7 @@ The primary key of the property, if applicable.
 
 > `readonly` `optional` **properties**: `object`
 
-Defined in: ridb\_core.d.ts:348
+Defined in: ridb\_core.d.ts:666
 
 An optional map of nested properties for object-type properties.
 
@@ -110,7 +110,7 @@ An optional map of nested properties for object-type properties.
 
 > `readonly` `optional` **required**: `boolean`
 
-Defined in: ridb\_core.d.ts:338
+Defined in: ridb\_core.d.ts:656
 
 An optional array of required fields for object-type properties.
 
@@ -120,7 +120,7 @@ An optional array of required fields for object-type properties.
 
 > `readonly` **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:298
+Defined in: ridb\_core.d.ts:616
 
 The type of the property.
 
@@ -130,6 +130,6 @@ The type of the property.
 
 > `readonly` `optional` **version**: `number`
 
-Defined in: ridb\_core.d.ts:303
+Defined in: ridb\_core.d.ts:621
 
 The version of the property, if applicable.

--- a/docs/@trust0/ridb-core/classes/Query.md
+++ b/docs/@trust0/ridb-core/classes/Query.md
@@ -6,7 +6,7 @@
 
 # Class: Query\<T\>
 
-Defined in: ridb\_core.d.ts:380
+Defined in: ridb\_core.d.ts:579
 
 ## Type Parameters
 
@@ -20,7 +20,7 @@ Defined in: ridb\_core.d.ts:380
 
 > **new Query**\<`T`\>(`query`, `schema`): `Query`\<`T`\>
 
-Defined in: ridb\_core.d.ts:381
+Defined in: ridb\_core.d.ts:580
 
 #### Parameters
 
@@ -42,4 +42,4 @@ Defined in: ridb\_core.d.ts:381
 
 > `readonly` **query**: [`QueryType`](../type-aliases/QueryType.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:382
+Defined in: ridb\_core.d.ts:581

--- a/docs/@trust0/ridb-core/classes/Query.md
+++ b/docs/@trust0/ridb-core/classes/Query.md
@@ -6,7 +6,7 @@
 
 # Class: Query\<T\>
 
-Defined in: ridb\_core.d.ts:423
+Defined in: ridb\_core.d.ts:380
 
 ## Type Parameters
 
@@ -20,7 +20,7 @@ Defined in: ridb\_core.d.ts:423
 
 > **new Query**\<`T`\>(`query`, `schema`): `Query`\<`T`\>
 
-Defined in: ridb\_core.d.ts:424
+Defined in: ridb\_core.d.ts:381
 
 #### Parameters
 
@@ -42,4 +42,4 @@ Defined in: ridb\_core.d.ts:424
 
 > `readonly` **query**: [`QueryType`](../type-aliases/QueryType.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:425
+Defined in: ridb\_core.d.ts:382

--- a/docs/@trust0/ridb-core/classes/Query.md
+++ b/docs/@trust0/ridb-core/classes/Query.md
@@ -6,7 +6,7 @@
 
 # Class: Query\<T\>
 
-Defined in: ridb\_core.d.ts:487
+Defined in: ridb\_core.d.ts:284
 
 ## Type Parameters
 
@@ -20,7 +20,7 @@ Defined in: ridb\_core.d.ts:487
 
 > **new Query**\<`T`\>(`query`, `schema`): `Query`\<`T`\>
 
-Defined in: ridb\_core.d.ts:488
+Defined in: ridb\_core.d.ts:285
 
 #### Parameters
 
@@ -42,4 +42,4 @@ Defined in: ridb\_core.d.ts:488
 
 > `readonly` **query**: [`QueryType`](../type-aliases/QueryType.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:489
+Defined in: ridb\_core.d.ts:286

--- a/docs/@trust0/ridb-core/classes/Query.md
+++ b/docs/@trust0/ridb-core/classes/Query.md
@@ -6,7 +6,7 @@
 
 # Class: Query\<T\>
 
-Defined in: ridb\_core.d.ts:284
+Defined in: ridb\_core.d.ts:423
 
 ## Type Parameters
 
@@ -20,7 +20,7 @@ Defined in: ridb\_core.d.ts:284
 
 > **new Query**\<`T`\>(`query`, `schema`): `Query`\<`T`\>
 
-Defined in: ridb\_core.d.ts:285
+Defined in: ridb\_core.d.ts:424
 
 #### Parameters
 
@@ -42,4 +42,4 @@ Defined in: ridb\_core.d.ts:285
 
 > `readonly` **query**: [`QueryType`](../type-aliases/QueryType.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:286
+Defined in: ridb\_core.d.ts:425

--- a/docs/@trust0/ridb-core/classes/Schema.md
+++ b/docs/@trust0/ridb-core/classes/Schema.md
@@ -6,7 +6,7 @@
 
 # Class: Schema\<T\>
 
-Defined in: ridb\_core.d.ts:697
+Defined in: ridb\_core.d.ts:150
 
 Represents a schema, including its definition and related methods.
 You may be trying to build a storage, in any other can u won't need access tho this class.
@@ -45,7 +45,7 @@ The schema type.
 
 > `readonly` `optional` **encrypted**: `Extract`\<keyof `T`, `string`\>[]
 
-Defined in: ridb\_core.d.ts:738
+Defined in: ridb\_core.d.ts:191
 
 An optional array of encrypted fields.
 
@@ -55,7 +55,7 @@ An optional array of encrypted fields.
 
 > `readonly` `optional` **indexes**: `Extract`\<keyof `T`, `string`\>[]
 
-Defined in: ridb\_core.d.ts:733
+Defined in: ridb\_core.d.ts:186
 
 An optional array of indexes.
 
@@ -65,7 +65,7 @@ An optional array of indexes.
 
 > `readonly` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:720
+Defined in: ridb\_core.d.ts:173
 
 The primary key of the schema.
 
@@ -75,7 +75,7 @@ The primary key of the schema.
 
 > `readonly` **properties**: \{ \[K in string \| number \| symbol as T\["properties"\]\[K\]\["required"\] extends false \| (T\["properties"\]\[K\]\["default"\] extends undefined ? true : false) ? K : never\]?: T\["properties"\]\[K\] \} & \{ \[K in string \| number \| symbol as T\["properties"\]\[K\]\["required"\] extends false ? never : K\]: T\["properties"\]\[K\] \}
 
-Defined in: ridb\_core.d.ts:743
+Defined in: ridb\_core.d.ts:196
 
 The properties defined in the schema.
 
@@ -85,7 +85,7 @@ The properties defined in the schema.
 
 > **schema**: `Schema`\<`T`\>
 
-Defined in: ridb\_core.d.ts:701
+Defined in: ridb\_core.d.ts:154
 
 The schema definition.
 
@@ -95,7 +95,7 @@ The schema definition.
 
 > `readonly` **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:725
+Defined in: ridb\_core.d.ts:178
 
 The type of the schema.
 
@@ -105,7 +105,7 @@ The type of the schema.
 
 > `readonly` **version**: `number`
 
-Defined in: ridb\_core.d.ts:715
+Defined in: ridb\_core.d.ts:168
 
 The version of the schema.
 
@@ -115,7 +115,7 @@ The version of the schema.
 
 > **toJSON**(): [`SchemaType`](../type-aliases/SchemaType.md)
 
-Defined in: ridb\_core.d.ts:753
+Defined in: ridb\_core.d.ts:206
 
 Converts the schema to a JSON representation.
 
@@ -131,7 +131,7 @@ The JSON representation of the schema.
 
 > **validate**(`document`): `boolean`
 
-Defined in: ridb\_core.d.ts:755
+Defined in: ridb\_core.d.ts:208
 
 #### Parameters
 
@@ -149,7 +149,7 @@ Defined in: ridb\_core.d.ts:755
 
 > `static` **create**\<`TS`\>(`definition`): `Schema`\<`TS`\>
 
-Defined in: ridb\_core.d.ts:710
+Defined in: ridb\_core.d.ts:163
 
 Creates a new `Schema` instance from the provided definition.
 

--- a/docs/@trust0/ridb-core/classes/Schema.md
+++ b/docs/@trust0/ridb-core/classes/Schema.md
@@ -6,7 +6,7 @@
 
 # Class: Schema\<T\>
 
-Defined in: ridb\_core.d.ts:546
+Defined in: ridb\_core.d.ts:697
 
 Represents a schema, including its definition and related methods.
 You may be trying to build a storage, in any other can u won't need access tho this class.
@@ -45,7 +45,7 @@ The schema type.
 
 > `readonly` `optional` **encrypted**: `Extract`\<keyof `T`, `string`\>[]
 
-Defined in: ridb\_core.d.ts:587
+Defined in: ridb\_core.d.ts:738
 
 An optional array of encrypted fields.
 
@@ -55,7 +55,7 @@ An optional array of encrypted fields.
 
 > `readonly` `optional` **indexes**: `Extract`\<keyof `T`, `string`\>[]
 
-Defined in: ridb\_core.d.ts:582
+Defined in: ridb\_core.d.ts:733
 
 An optional array of indexes.
 
@@ -65,7 +65,7 @@ An optional array of indexes.
 
 > `readonly` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:569
+Defined in: ridb\_core.d.ts:720
 
 The primary key of the schema.
 
@@ -75,7 +75,7 @@ The primary key of the schema.
 
 > `readonly` **properties**: \{ \[K in string \| number \| symbol as T\["properties"\]\[K\]\["required"\] extends false \| (T\["properties"\]\[K\]\["default"\] extends undefined ? true : false) ? K : never\]?: T\["properties"\]\[K\] \} & \{ \[K in string \| number \| symbol as T\["properties"\]\[K\]\["required"\] extends false ? never : K\]: T\["properties"\]\[K\] \}
 
-Defined in: ridb\_core.d.ts:592
+Defined in: ridb\_core.d.ts:743
 
 The properties defined in the schema.
 
@@ -85,7 +85,7 @@ The properties defined in the schema.
 
 > **schema**: `Schema`\<`T`\>
 
-Defined in: ridb\_core.d.ts:550
+Defined in: ridb\_core.d.ts:701
 
 The schema definition.
 
@@ -95,7 +95,7 @@ The schema definition.
 
 > `readonly` **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:574
+Defined in: ridb\_core.d.ts:725
 
 The type of the schema.
 
@@ -105,7 +105,7 @@ The type of the schema.
 
 > `readonly` **version**: `number`
 
-Defined in: ridb\_core.d.ts:564
+Defined in: ridb\_core.d.ts:715
 
 The version of the schema.
 
@@ -115,7 +115,7 @@ The version of the schema.
 
 > **toJSON**(): [`SchemaType`](../type-aliases/SchemaType.md)
 
-Defined in: ridb\_core.d.ts:602
+Defined in: ridb\_core.d.ts:753
 
 Converts the schema to a JSON representation.
 
@@ -131,7 +131,7 @@ The JSON representation of the schema.
 
 > **validate**(`document`): `boolean`
 
-Defined in: ridb\_core.d.ts:604
+Defined in: ridb\_core.d.ts:755
 
 #### Parameters
 
@@ -149,7 +149,7 @@ Defined in: ridb\_core.d.ts:604
 
 > `static` **create**\<`TS`\>(`definition`): `Schema`\<`TS`\>
 
-Defined in: ridb\_core.d.ts:559
+Defined in: ridb\_core.d.ts:710
 
 Creates a new `Schema` instance from the provided definition.
 

--- a/docs/@trust0/ridb-core/classes/Schema.md
+++ b/docs/@trust0/ridb-core/classes/Schema.md
@@ -6,7 +6,7 @@
 
 # Class: Schema\<T\>
 
-Defined in: ridb\_core.d.ts:121
+Defined in: ridb\_core.d.ts:400
 
 Represents a schema, including its definition and related methods.
 You may be trying to build a storage, in any other can u won't need access tho this class.
@@ -45,7 +45,7 @@ The schema type.
 
 > `readonly` `optional` **encrypted**: `Extract`\<keyof `T`, `string`\>[]
 
-Defined in: ridb\_core.d.ts:162
+Defined in: ridb\_core.d.ts:441
 
 An optional array of encrypted fields.
 
@@ -55,7 +55,7 @@ An optional array of encrypted fields.
 
 > `readonly` `optional` **indexes**: `Extract`\<keyof `T`, `string`\>[]
 
-Defined in: ridb\_core.d.ts:157
+Defined in: ridb\_core.d.ts:436
 
 An optional array of indexes.
 
@@ -65,7 +65,7 @@ An optional array of indexes.
 
 > `readonly` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:144
+Defined in: ridb\_core.d.ts:423
 
 The primary key of the schema.
 
@@ -75,7 +75,7 @@ The primary key of the schema.
 
 > `readonly` **properties**: \{ \[K in string \| number \| symbol as T\["properties"\]\[K\]\["required"\] extends false \| (T\["properties"\]\[K\]\["default"\] extends undefined ? true : false) ? K : never\]?: T\["properties"\]\[K\] \} & \{ \[K in string \| number \| symbol as T\["properties"\]\[K\]\["required"\] extends false ? never : K\]: T\["properties"\]\[K\] \}
 
-Defined in: ridb\_core.d.ts:167
+Defined in: ridb\_core.d.ts:446
 
 The properties defined in the schema.
 
@@ -85,7 +85,7 @@ The properties defined in the schema.
 
 > **schema**: `Schema`\<`T`\>
 
-Defined in: ridb\_core.d.ts:125
+Defined in: ridb\_core.d.ts:404
 
 The schema definition.
 
@@ -95,7 +95,7 @@ The schema definition.
 
 > `readonly` **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:149
+Defined in: ridb\_core.d.ts:428
 
 The type of the schema.
 
@@ -105,7 +105,7 @@ The type of the schema.
 
 > `readonly` **version**: `number`
 
-Defined in: ridb\_core.d.ts:139
+Defined in: ridb\_core.d.ts:418
 
 The version of the schema.
 
@@ -115,7 +115,7 @@ The version of the schema.
 
 > **toJSON**(): [`SchemaType`](../type-aliases/SchemaType.md)
 
-Defined in: ridb\_core.d.ts:177
+Defined in: ridb\_core.d.ts:456
 
 Converts the schema to a JSON representation.
 
@@ -131,7 +131,7 @@ The JSON representation of the schema.
 
 > **validate**(`document`): `boolean`
 
-Defined in: ridb\_core.d.ts:179
+Defined in: ridb\_core.d.ts:458
 
 #### Parameters
 
@@ -149,7 +149,7 @@ Defined in: ridb\_core.d.ts:179
 
 > `static` **create**\<`TS`\>(`definition`): `Schema`\<`TS`\>
 
-Defined in: ridb\_core.d.ts:134
+Defined in: ridb\_core.d.ts:413
 
 Creates a new `Schema` instance from the provided definition.
 

--- a/docs/@trust0/ridb-core/classes/Schema.md
+++ b/docs/@trust0/ridb-core/classes/Schema.md
@@ -6,7 +6,7 @@
 
 # Class: Schema\<T\>
 
-Defined in: ridb\_core.d.ts:400
+Defined in: ridb\_core.d.ts:546
 
 Represents a schema, including its definition and related methods.
 You may be trying to build a storage, in any other can u won't need access tho this class.
@@ -45,7 +45,7 @@ The schema type.
 
 > `readonly` `optional` **encrypted**: `Extract`\<keyof `T`, `string`\>[]
 
-Defined in: ridb\_core.d.ts:441
+Defined in: ridb\_core.d.ts:587
 
 An optional array of encrypted fields.
 
@@ -55,7 +55,7 @@ An optional array of encrypted fields.
 
 > `readonly` `optional` **indexes**: `Extract`\<keyof `T`, `string`\>[]
 
-Defined in: ridb\_core.d.ts:436
+Defined in: ridb\_core.d.ts:582
 
 An optional array of indexes.
 
@@ -65,7 +65,7 @@ An optional array of indexes.
 
 > `readonly` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:423
+Defined in: ridb\_core.d.ts:569
 
 The primary key of the schema.
 
@@ -75,7 +75,7 @@ The primary key of the schema.
 
 > `readonly` **properties**: \{ \[K in string \| number \| symbol as T\["properties"\]\[K\]\["required"\] extends false \| (T\["properties"\]\[K\]\["default"\] extends undefined ? true : false) ? K : never\]?: T\["properties"\]\[K\] \} & \{ \[K in string \| number \| symbol as T\["properties"\]\[K\]\["required"\] extends false ? never : K\]: T\["properties"\]\[K\] \}
 
-Defined in: ridb\_core.d.ts:446
+Defined in: ridb\_core.d.ts:592
 
 The properties defined in the schema.
 
@@ -85,7 +85,7 @@ The properties defined in the schema.
 
 > **schema**: `Schema`\<`T`\>
 
-Defined in: ridb\_core.d.ts:404
+Defined in: ridb\_core.d.ts:550
 
 The schema definition.
 
@@ -95,7 +95,7 @@ The schema definition.
 
 > `readonly` **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:428
+Defined in: ridb\_core.d.ts:574
 
 The type of the schema.
 
@@ -105,7 +105,7 @@ The type of the schema.
 
 > `readonly` **version**: `number`
 
-Defined in: ridb\_core.d.ts:418
+Defined in: ridb\_core.d.ts:564
 
 The version of the schema.
 
@@ -115,7 +115,7 @@ The version of the schema.
 
 > **toJSON**(): [`SchemaType`](../type-aliases/SchemaType.md)
 
-Defined in: ridb\_core.d.ts:456
+Defined in: ridb\_core.d.ts:602
 
 Converts the schema to a JSON representation.
 
@@ -131,7 +131,7 @@ The JSON representation of the schema.
 
 > **validate**(`document`): `boolean`
 
-Defined in: ridb\_core.d.ts:458
+Defined in: ridb\_core.d.ts:604
 
 #### Parameters
 
@@ -149,7 +149,7 @@ Defined in: ridb\_core.d.ts:458
 
 > `static` **create**\<`TS`\>(`definition`): `Schema`\<`TS`\>
 
-Defined in: ridb\_core.d.ts:413
+Defined in: ridb\_core.d.ts:559
 
 Creates a new `Schema` instance from the provided definition.
 

--- a/docs/@trust0/ridb-core/classes/StorageInternal.md
+++ b/docs/@trust0/ridb-core/classes/StorageInternal.md
@@ -6,7 +6,7 @@
 
 # Class: `abstract` StorageInternal\<Schemas\>
 
-Defined in: ridb\_core.d.ts:733
+Defined in: ridb\_core.d.ts:589
 
 ## Extended by
 
@@ -24,7 +24,7 @@ Defined in: ridb\_core.d.ts:733
 
 > **new StorageInternal**\<`Schemas`\>(`name`, `schemas`): `StorageInternal`\<`Schemas`\>
 
-Defined in: ridb\_core.d.ts:734
+Defined in: ridb\_core.d.ts:590
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:734
 
 > `abstract` **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:739
+Defined in: ridb\_core.d.ts:595
 
 #### Returns
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:739
 
 > `abstract` **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:740
+Defined in: ridb\_core.d.ts:596
 
 #### Parameters
 
@@ -84,7 +84,7 @@ keyof `Schemas`
 
 > `abstract` **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:749
+Defined in: ridb\_core.d.ts:605
 
 #### Parameters
 
@@ -110,7 +110,7 @@ keyof `Schemas`
 
 > `abstract` **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:745
+Defined in: ridb\_core.d.ts:601
 
 #### Parameters
 
@@ -132,7 +132,7 @@ keyof `Schemas`
 
 > `abstract` **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:738
+Defined in: ridb\_core.d.ts:594
 
 #### Returns
 
@@ -144,7 +144,7 @@ Defined in: ridb\_core.d.ts:738
 
 > `abstract` **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:754
+Defined in: ridb\_core.d.ts:610
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/classes/StorageInternal.md
+++ b/docs/@trust0/ridb-core/classes/StorageInternal.md
@@ -6,7 +6,7 @@
 
 # Class: `abstract` StorageInternal\<Schemas\>
 
-Defined in: ridb\_core.d.ts:466
+Defined in: ridb\_core.d.ts:685
 
 ## Extended by
 
@@ -24,7 +24,7 @@ Defined in: ridb\_core.d.ts:466
 
 > **new StorageInternal**\<`Schemas`\>(`name`, `schemas`): `StorageInternal`\<`Schemas`\>
 
-Defined in: ridb\_core.d.ts:467
+Defined in: ridb\_core.d.ts:686
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:467
 
 > `abstract` **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:472
+Defined in: ridb\_core.d.ts:691
 
 #### Returns
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:472
 
 > `abstract` **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:473
+Defined in: ridb\_core.d.ts:692
 
 #### Parameters
 
@@ -84,7 +84,7 @@ keyof `Schemas`
 
 > `abstract` **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:482
+Defined in: ridb\_core.d.ts:701
 
 #### Parameters
 
@@ -110,7 +110,7 @@ keyof `Schemas`
 
 > `abstract` **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:478
+Defined in: ridb\_core.d.ts:697
 
 #### Parameters
 
@@ -132,7 +132,7 @@ keyof `Schemas`
 
 > `abstract` **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:471
+Defined in: ridb\_core.d.ts:690
 
 #### Returns
 
@@ -144,7 +144,7 @@ Defined in: ridb\_core.d.ts:471
 
 > `abstract` **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:487
+Defined in: ridb\_core.d.ts:706
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/classes/StorageInternal.md
+++ b/docs/@trust0/ridb-core/classes/StorageInternal.md
@@ -6,7 +6,7 @@
 
 # Class: `abstract` StorageInternal\<Schemas\>
 
-Defined in: ridb\_core.d.ts:589
+Defined in: ridb\_core.d.ts:681
 
 ## Extended by
 
@@ -24,7 +24,7 @@ Defined in: ridb\_core.d.ts:589
 
 > **new StorageInternal**\<`Schemas`\>(`name`, `schemas`): `StorageInternal`\<`Schemas`\>
 
-Defined in: ridb\_core.d.ts:590
+Defined in: ridb\_core.d.ts:682
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:590
 
 > `abstract` **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:595
+Defined in: ridb\_core.d.ts:687
 
 #### Returns
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:595
 
 > `abstract` **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:596
+Defined in: ridb\_core.d.ts:688
 
 #### Parameters
 
@@ -84,7 +84,7 @@ keyof `Schemas`
 
 > `abstract` **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:605
+Defined in: ridb\_core.d.ts:697
 
 #### Parameters
 
@@ -110,7 +110,7 @@ keyof `Schemas`
 
 > `abstract` **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:601
+Defined in: ridb\_core.d.ts:693
 
 #### Parameters
 
@@ -132,7 +132,7 @@ keyof `Schemas`
 
 > `abstract` **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:594
+Defined in: ridb\_core.d.ts:686
 
 #### Returns
 
@@ -144,7 +144,7 @@ Defined in: ridb\_core.d.ts:594
 
 > `abstract` **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:610
+Defined in: ridb\_core.d.ts:702
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/classes/StorageInternal.md
+++ b/docs/@trust0/ridb-core/classes/StorageInternal.md
@@ -6,7 +6,7 @@
 
 # Class: `abstract` StorageInternal\<Schemas\>
 
-Defined in: ridb\_core.d.ts:681
+Defined in: ridb\_core.d.ts:466
 
 ## Extended by
 
@@ -24,7 +24,7 @@ Defined in: ridb\_core.d.ts:681
 
 > **new StorageInternal**\<`Schemas`\>(`name`, `schemas`): `StorageInternal`\<`Schemas`\>
 
-Defined in: ridb\_core.d.ts:682
+Defined in: ridb\_core.d.ts:467
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:682
 
 > `abstract` **close**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:687
+Defined in: ridb\_core.d.ts:472
 
 #### Returns
 
@@ -58,7 +58,7 @@ Defined in: ridb\_core.d.ts:687
 
 > `abstract` **count**(`colectionName`, `query`, `options?`): `Promise`\<`number`\>
 
-Defined in: ridb\_core.d.ts:688
+Defined in: ridb\_core.d.ts:473
 
 #### Parameters
 
@@ -84,7 +84,7 @@ keyof `Schemas`
 
 > `abstract` **find**(`collectionName`, `query`, `options?`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>[]\>
 
-Defined in: ridb\_core.d.ts:697
+Defined in: ridb\_core.d.ts:482
 
 #### Parameters
 
@@ -110,7 +110,7 @@ keyof `Schemas`
 
 > `abstract` **findDocumentById**(`collectionName`, `id`): `Promise`\<`null` \| [`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:693
+Defined in: ridb\_core.d.ts:478
 
 #### Parameters
 
@@ -132,7 +132,7 @@ keyof `Schemas`
 
 > `abstract` **start**(): `Promise`\<`void`\>
 
-Defined in: ridb\_core.d.ts:686
+Defined in: ridb\_core.d.ts:471
 
 #### Returns
 
@@ -144,7 +144,7 @@ Defined in: ridb\_core.d.ts:686
 
 > `abstract` **write**(`op`): `Promise`\<[`Doc`](../type-aliases/Doc.md)\<`Schemas`\[keyof `Schemas`\]\>\>
 
-Defined in: ridb\_core.d.ts:702
+Defined in: ridb\_core.d.ts:487
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/enumerations/Errors.md
+++ b/docs/@trust0/ridb-core/enumerations/Errors.md
@@ -6,7 +6,7 @@
 
 # Enumeration: Errors
 
-Defined in: ridb\_core.d.ts:67
+Defined in: ridb\_core.d.ts:42
 
 ## Enumeration Members
 
@@ -14,7 +14,7 @@ Defined in: ridb\_core.d.ts:67
 
 > **AuthenticationError**: `5`
 
-Defined in: ridb\_core.d.ts:73
+Defined in: ridb\_core.d.ts:48
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: ridb\_core.d.ts:73
 
 > **Error**: `0`
 
-Defined in: ridb\_core.d.ts:68
+Defined in: ridb\_core.d.ts:43
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: ridb\_core.d.ts:68
 
 > **HookError**: `1`
 
-Defined in: ridb\_core.d.ts:69
+Defined in: ridb\_core.d.ts:44
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: ridb\_core.d.ts:69
 
 > **QueryError**: `2`
 
-Defined in: ridb\_core.d.ts:70
+Defined in: ridb\_core.d.ts:45
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:70
 
 > **SerializationError**: `3`
 
-Defined in: ridb\_core.d.ts:71
+Defined in: ridb\_core.d.ts:46
 
 ***
 
@@ -54,4 +54,4 @@ Defined in: ridb\_core.d.ts:71
 
 > **ValidationError**: `4`
 
-Defined in: ridb\_core.d.ts:72
+Defined in: ridb\_core.d.ts:47

--- a/docs/@trust0/ridb-core/enumerations/Errors.md
+++ b/docs/@trust0/ridb-core/enumerations/Errors.md
@@ -6,7 +6,7 @@
 
 # Enumeration: Errors
 
-Defined in: ridb\_core.d.ts:42
+Defined in: ridb\_core.d.ts:67
 
 ## Enumeration Members
 
@@ -14,7 +14,7 @@ Defined in: ridb\_core.d.ts:42
 
 > **AuthenticationError**: `5`
 
-Defined in: ridb\_core.d.ts:48
+Defined in: ridb\_core.d.ts:73
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: ridb\_core.d.ts:48
 
 > **Error**: `0`
 
-Defined in: ridb\_core.d.ts:43
+Defined in: ridb\_core.d.ts:68
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: ridb\_core.d.ts:43
 
 > **HookError**: `1`
 
-Defined in: ridb\_core.d.ts:44
+Defined in: ridb\_core.d.ts:69
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: ridb\_core.d.ts:44
 
 > **QueryError**: `2`
 
-Defined in: ridb\_core.d.ts:45
+Defined in: ridb\_core.d.ts:70
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:45
 
 > **SerializationError**: `3`
 
-Defined in: ridb\_core.d.ts:46
+Defined in: ridb\_core.d.ts:71
 
 ***
 
@@ -54,4 +54,4 @@ Defined in: ridb\_core.d.ts:46
 
 > **ValidationError**: `4`
 
-Defined in: ridb\_core.d.ts:47
+Defined in: ridb\_core.d.ts:72

--- a/docs/@trust0/ridb-core/enumerations/OpType.md
+++ b/docs/@trust0/ridb-core/enumerations/OpType.md
@@ -6,7 +6,7 @@
 
 # Enumeration: OpType
 
-Defined in: ridb\_core.d.ts:43
+Defined in: ridb\_core.d.ts:53
 
 Represents the type of operation to be performed on the collection.
 
@@ -16,7 +16,7 @@ Represents the type of operation to be performed on the collection.
 
 > **COUNT**: `4`
 
-Defined in: ridb\_core.d.ts:63
+Defined in: ridb\_core.d.ts:73
 
 Count Operation.
 
@@ -26,7 +26,7 @@ Count Operation.
 
 > **CREATE**: `0`
 
-Defined in: ridb\_core.d.ts:47
+Defined in: ridb\_core.d.ts:57
 
 Create operation.
 
@@ -36,7 +36,7 @@ Create operation.
 
 > **DELETE**: `2`
 
-Defined in: ridb\_core.d.ts:55
+Defined in: ridb\_core.d.ts:65
 
 Delete operation.
 
@@ -46,7 +46,7 @@ Delete operation.
 
 > **QUERY**: `3`
 
-Defined in: ridb\_core.d.ts:59
+Defined in: ridb\_core.d.ts:69
 
 Query Operation.
 
@@ -56,6 +56,6 @@ Query Operation.
 
 > **UPDATE**: `1`
 
-Defined in: ridb\_core.d.ts:51
+Defined in: ridb\_core.d.ts:61
 
 Update operation.

--- a/docs/@trust0/ridb-core/enumerations/OpType.md
+++ b/docs/@trust0/ridb-core/enumerations/OpType.md
@@ -6,7 +6,7 @@
 
 # Enumeration: OpType
 
-Defined in: ridb\_core.d.ts:53
+Defined in: ridb\_core.d.ts:43
 
 Represents the type of operation to be performed on the collection.
 
@@ -16,7 +16,7 @@ Represents the type of operation to be performed on the collection.
 
 > **COUNT**: `4`
 
-Defined in: ridb\_core.d.ts:73
+Defined in: ridb\_core.d.ts:63
 
 Count Operation.
 
@@ -26,7 +26,7 @@ Count Operation.
 
 > **CREATE**: `0`
 
-Defined in: ridb\_core.d.ts:57
+Defined in: ridb\_core.d.ts:47
 
 Create operation.
 
@@ -36,7 +36,7 @@ Create operation.
 
 > **DELETE**: `2`
 
-Defined in: ridb\_core.d.ts:65
+Defined in: ridb\_core.d.ts:55
 
 Delete operation.
 
@@ -46,7 +46,7 @@ Delete operation.
 
 > **QUERY**: `3`
 
-Defined in: ridb\_core.d.ts:69
+Defined in: ridb\_core.d.ts:59
 
 Query Operation.
 
@@ -56,6 +56,6 @@ Query Operation.
 
 > **UPDATE**: `1`
 
-Defined in: ridb\_core.d.ts:61
+Defined in: ridb\_core.d.ts:51
 
 Update operation.

--- a/docs/@trust0/ridb-core/functions/initSync.md
+++ b/docs/@trust0/ridb-core/functions/initSync.md
@@ -8,7 +8,7 @@
 
 > **initSync**(`module`): [`InitOutput`](../interfaces/InitOutput.md)
 
-Defined in: ridb\_core.d.ts:1042
+Defined in: ridb\_core.d.ts:1043
 
 Instantiates the given `module`, which can either be bytes or
 a precompiled `WebAssembly.Module`.

--- a/docs/@trust0/ridb-core/functions/initSync.md
+++ b/docs/@trust0/ridb-core/functions/initSync.md
@@ -8,7 +8,7 @@
 
 > **initSync**(`module`): [`InitOutput`](../interfaces/InitOutput.md)
 
-Defined in: ridb\_core.d.ts:1041
+Defined in: ridb\_core.d.ts:1042
 
 Instantiates the given `module`, which can either be bytes or
 a precompiled `WebAssembly.Module`.

--- a/docs/@trust0/ridb-core/functions/wbg_init.md
+++ b/docs/@trust0/ridb-core/functions/wbg_init.md
@@ -8,7 +8,7 @@
 
 > **\_\_wbg\_init**(`module_or_path?`): `Promise`\<[`InitOutput`](../interfaces/InitOutput.md)\>
 
-Defined in: ridb\_core.d.ts:1052
+Defined in: ridb\_core.d.ts:1053
 
 If `module_or_path` is {RequestInfo} or {URL}, makes a request and
 for everything else, calls `WebAssembly.instantiate` directly.

--- a/docs/@trust0/ridb-core/functions/wbg_init.md
+++ b/docs/@trust0/ridb-core/functions/wbg_init.md
@@ -8,7 +8,7 @@
 
 > **\_\_wbg\_init**(`module_or_path?`): `Promise`\<[`InitOutput`](../interfaces/InitOutput.md)\>
 
-Defined in: ridb\_core.d.ts:1051
+Defined in: ridb\_core.d.ts:1052
 
 If `module_or_path` is {RequestInfo} or {URL}, makes a request and
 for everything else, calls `WebAssembly.instantiate` directly.

--- a/docs/@trust0/ridb-core/interfaces/InitOutput.md
+++ b/docs/@trust0/ridb-core/interfaces/InitOutput.md
@@ -14,7 +14,7 @@ Defined in: ridb\_core.d.ts:868
 
 > `readonly` **\_\_wbg\_baseplugin\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:975
+Defined in: ridb\_core.d.ts:908
 
 #### Parameters
 
@@ -32,7 +32,7 @@ Defined in: ridb\_core.d.ts:975
 
 > `readonly` **\_\_wbg\_basestorage\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:880
+Defined in: ridb\_core.d.ts:892
 
 #### Parameters
 
@@ -68,7 +68,7 @@ Defined in: ridb\_core.d.ts:870
 
 > `readonly` **\_\_wbg\_corestorage\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1008
+Defined in: ridb\_core.d.ts:891
 
 #### Parameters
 
@@ -86,7 +86,7 @@ Defined in: ridb\_core.d.ts:1008
 
 > `readonly` **\_\_wbg\_database\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:993
+Defined in: ridb\_core.d.ts:898
 
 #### Parameters
 
@@ -104,7 +104,7 @@ Defined in: ridb\_core.d.ts:993
 
 > `readonly` **\_\_wbg\_indexdb\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:900
+Defined in: ridb\_core.d.ts:999
 
 #### Parameters
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:900
 
 > `readonly` **\_\_wbg\_inmemory\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:982
+Defined in: ridb\_core.d.ts:952
 
 #### Parameters
 
@@ -140,7 +140,7 @@ Defined in: ridb\_core.d.ts:982
 
 > `readonly` **\_\_wbg\_operation\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1000
+Defined in: ridb\_core.d.ts:883
 
 #### Parameters
 
@@ -158,7 +158,7 @@ Defined in: ridb\_core.d.ts:1000
 
 > `readonly` **\_\_wbg\_property\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:950
+Defined in: ridb\_core.d.ts:987
 
 #### Parameters
 
@@ -176,7 +176,7 @@ Defined in: ridb\_core.d.ts:950
 
 > `readonly` **\_\_wbg\_query\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:913
+Defined in: ridb\_core.d.ts:915
 
 #### Parameters
 
@@ -194,7 +194,7 @@ Defined in: ridb\_core.d.ts:913
 
 > `readonly` **\_\_wbg\_queryoptions\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:910
+Defined in: ridb\_core.d.ts:905
 
 #### Parameters
 
@@ -212,7 +212,7 @@ Defined in: ridb\_core.d.ts:910
 
 > `readonly` **\_\_wbg\_ridberror\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:888
+Defined in: ridb\_core.d.ts:962
 
 #### Parameters
 
@@ -230,7 +230,7 @@ Defined in: ridb\_core.d.ts:888
 
 > `readonly` **\_\_wbg\_schema\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:962
+Defined in: ridb\_core.d.ts:974
 
 #### Parameters
 
@@ -266,7 +266,7 @@ Defined in: ridb\_core.d.ts:1009
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_array\_values\_10**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:925
+Defined in: ridb\_core.d.ts:927
 
 #### Parameters
 
@@ -284,7 +284,7 @@ Defined in: ridb\_core.d.ts:925
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_deeply\_nested\_12**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:927
+Defined in: ridb\_core.d.ts:929
 
 #### Parameters
 
@@ -302,7 +302,7 @@ Defined in: ridb\_core.d.ts:927
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_empty\_query\_11**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:926
+Defined in: ridb\_core.d.ts:928
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:926
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_nested\_operators\_9**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:924
+Defined in: ridb\_core.d.ts:926
 
 #### Parameters
 
@@ -338,7 +338,7 @@ Defined in: ridb\_core.d.ts:924
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_simple\_fields\_6**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:921
+Defined in: ridb\_core.d.ts:923
 
 #### Parameters
 
@@ -356,7 +356,7 @@ Defined in: ridb\_core.d.ts:921
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_array\_at\_top\_level\_14**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:929
+Defined in: ridb\_core.d.ts:931
 
 #### Parameters
 
@@ -374,7 +374,7 @@ Defined in: ridb\_core.d.ts:929
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_logical\_operators\_8**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:923
+Defined in: ridb\_core.d.ts:925
 
 #### Parameters
 
@@ -392,7 +392,7 @@ Defined in: ridb\_core.d.ts:923
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_multiple\_same\_props\_13**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:928
+Defined in: ridb\_core.d.ts:930
 
 #### Parameters
 
@@ -410,7 +410,7 @@ Defined in: ridb\_core.d.ts:928
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_operators\_7**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:922
+Defined in: ridb\_core.d.ts:924
 
 #### Parameters
 
@@ -428,7 +428,7 @@ Defined in: ridb\_core.d.ts:922
 
 > `readonly` **\_\_wbgt\_test\_invalid\_property\_2**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:961
+Defined in: ridb\_core.d.ts:998
 
 #### Parameters
 
@@ -446,7 +446,7 @@ Defined in: ridb\_core.d.ts:961
 
 > `readonly` **\_\_wbgt\_test\_invalid\_schema\_5**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:974
+Defined in: ridb\_core.d.ts:986
 
 #### Parameters
 
@@ -464,7 +464,7 @@ Defined in: ridb\_core.d.ts:974
 
 > `readonly` **\_\_wbgt\_test\_property\_creation\_0**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:959
+Defined in: ridb\_core.d.ts:996
 
 #### Parameters
 
@@ -482,7 +482,7 @@ Defined in: ridb\_core.d.ts:959
 
 > `readonly` **\_\_wbgt\_test\_property\_validation\_1**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:960
+Defined in: ridb\_core.d.ts:997
 
 #### Parameters
 
@@ -500,7 +500,7 @@ Defined in: ridb\_core.d.ts:960
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_complex\_mixed\_22**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:937
+Defined in: ridb\_core.d.ts:939
 
 #### Parameters
 
@@ -518,7 +518,7 @@ Defined in: ridb\_core.d.ts:937
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_nested\_logical\_operators\_20**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:935
+Defined in: ridb\_core.d.ts:937
 
 #### Parameters
 
@@ -536,7 +536,7 @@ Defined in: ridb\_core.d.ts:935
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_only\_logical\_operator\_21**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:936
+Defined in: ridb\_core.d.ts:938
 
 #### Parameters
 
@@ -554,7 +554,7 @@ Defined in: ridb\_core.d.ts:936
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_simple\_attributes\_18**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:933
+Defined in: ridb\_core.d.ts:935
 
 #### Parameters
 
@@ -572,7 +572,7 @@ Defined in: ridb\_core.d.ts:933
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_with\_logical\_operator\_19**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:934
+Defined in: ridb\_core.d.ts:936
 
 #### Parameters
 
@@ -590,7 +590,7 @@ Defined in: ridb\_core.d.ts:934
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_age\_query\_24**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:939
+Defined in: ridb\_core.d.ts:941
 
 #### Parameters
 
@@ -608,7 +608,7 @@ Defined in: ridb\_core.d.ts:939
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_empty\_logical\_operators\_28**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:943
+Defined in: ridb\_core.d.ts:945
 
 #### Parameters
 
@@ -626,7 +626,7 @@ Defined in: ridb\_core.d.ts:943
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_empty\_query\_23**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:938
+Defined in: ridb\_core.d.ts:940
 
 #### Parameters
 
@@ -644,7 +644,7 @@ Defined in: ridb\_core.d.ts:938
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_eq\_operator\_31**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:946
+Defined in: ridb\_core.d.ts:948
 
 #### Parameters
 
@@ -662,7 +662,7 @@ Defined in: ridb\_core.d.ts:946
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_eq\_operator\_wrong\_type\_32**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:947
+Defined in: ridb\_core.d.ts:949
 
 #### Parameters
 
@@ -680,7 +680,7 @@ Defined in: ridb\_core.d.ts:947
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_in\_operator\_16**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:931
+Defined in: ridb\_core.d.ts:933
 
 #### Parameters
 
@@ -698,7 +698,7 @@ Defined in: ridb\_core.d.ts:931
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_in\_operator\_wrong\_type\_17**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:932
+Defined in: ridb\_core.d.ts:934
 
 #### Parameters
 
@@ -716,7 +716,7 @@ Defined in: ridb\_core.d.ts:932
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_invalid\_in\_operator\_27**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:942
+Defined in: ridb\_core.d.ts:944
 
 #### Parameters
 
@@ -734,7 +734,7 @@ Defined in: ridb\_core.d.ts:942
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_multiple\_operators\_26**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:941
+Defined in: ridb\_core.d.ts:943
 
 #### Parameters
 
@@ -752,7 +752,7 @@ Defined in: ridb\_core.d.ts:941
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_ne\_operator\_33**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:948
+Defined in: ridb\_core.d.ts:950
 
 #### Parameters
 
@@ -770,7 +770,7 @@ Defined in: ridb\_core.d.ts:948
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_ne\_operator\_wrong\_type\_34**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:949
+Defined in: ridb\_core.d.ts:951
 
 #### Parameters
 
@@ -788,7 +788,7 @@ Defined in: ridb\_core.d.ts:949
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_nin\_operator\_29**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:944
+Defined in: ridb\_core.d.ts:946
 
 #### Parameters
 
@@ -806,7 +806,7 @@ Defined in: ridb\_core.d.ts:944
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_nin\_operator\_wrong\_type\_30**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:945
+Defined in: ridb\_core.d.ts:947
 
 #### Parameters
 
@@ -824,7 +824,7 @@ Defined in: ridb\_core.d.ts:945
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_non\_object\_query\_25**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:940
+Defined in: ridb\_core.d.ts:942
 
 #### Parameters
 
@@ -842,7 +842,7 @@ Defined in: ridb\_core.d.ts:940
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_operator\_wrong\_type\_15**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:930
+Defined in: ridb\_core.d.ts:932
 
 #### Parameters
 
@@ -860,7 +860,7 @@ Defined in: ridb\_core.d.ts:930
 
 > `readonly` **\_\_wbgt\_test\_schema\_creation\_3**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:972
+Defined in: ridb\_core.d.ts:984
 
 #### Parameters
 
@@ -878,7 +878,7 @@ Defined in: ridb\_core.d.ts:972
 
 > `readonly` **\_\_wbgt\_test\_schema\_validation\_4**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:973
+Defined in: ridb\_core.d.ts:985
 
 #### Parameters
 
@@ -1210,7 +1210,7 @@ Defined in: ridb\_core.d.ts:1021
 
 > `readonly` **baseplugin\_get\_doc\_create\_hook**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:978
+Defined in: ridb\_core.d.ts:911
 
 #### Parameters
 
@@ -1228,7 +1228,7 @@ Defined in: ridb\_core.d.ts:978
 
 > `readonly` **baseplugin\_get\_doc\_recover\_hook**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:979
+Defined in: ridb\_core.d.ts:912
 
 #### Parameters
 
@@ -1246,7 +1246,7 @@ Defined in: ridb\_core.d.ts:979
 
 > `readonly` **baseplugin\_name**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:977
+Defined in: ridb\_core.d.ts:910
 
 #### Parameters
 
@@ -1264,7 +1264,7 @@ Defined in: ridb\_core.d.ts:977
 
 > `readonly` **baseplugin\_new**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:976
+Defined in: ridb\_core.d.ts:909
 
 #### Parameters
 
@@ -1290,7 +1290,7 @@ Defined in: ridb\_core.d.ts:976
 
 > `readonly` **baseplugin\_set\_doc\_create\_hook**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:980
+Defined in: ridb\_core.d.ts:913
 
 #### Parameters
 
@@ -1312,7 +1312,7 @@ Defined in: ridb\_core.d.ts:980
 
 > `readonly` **baseplugin\_set\_doc\_recover\_hook**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:981
+Defined in: ridb\_core.d.ts:914
 
 #### Parameters
 
@@ -1334,7 +1334,7 @@ Defined in: ridb\_core.d.ts:981
 
 > `readonly` **basestorage\_addIndexSchemas**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:882
+Defined in: ridb\_core.d.ts:894
 
 #### Parameters
 
@@ -1356,7 +1356,7 @@ Defined in: ridb\_core.d.ts:882
 
 > `readonly` **basestorage\_core**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:885
+Defined in: ridb\_core.d.ts:897
 
 #### Parameters
 
@@ -1378,7 +1378,7 @@ Defined in: ridb\_core.d.ts:885
 
 > `readonly` **basestorage\_getOption**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:883
+Defined in: ridb\_core.d.ts:895
 
 #### Parameters
 
@@ -1408,7 +1408,7 @@ Defined in: ridb\_core.d.ts:883
 
 > `readonly` **basestorage\_getSchema**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:884
+Defined in: ridb\_core.d.ts:896
 
 #### Parameters
 
@@ -1438,7 +1438,7 @@ Defined in: ridb\_core.d.ts:884
 
 > `readonly` **basestorage\_new**: (`a`, `b`, `c`, `d`, `e`) => `void`
 
-Defined in: ridb\_core.d.ts:881
+Defined in: ridb\_core.d.ts:893
 
 #### Parameters
 
@@ -1682,7 +1682,7 @@ Defined in: ridb\_core.d.ts:877
 
 > `readonly` **corestorage\_getIndexes**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:991
+Defined in: ridb\_core.d.ts:881
 
 #### Parameters
 
@@ -1712,7 +1712,7 @@ Defined in: ridb\_core.d.ts:991
 
 > `readonly` **corestorage\_getPrimaryKeyTyped**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:990
+Defined in: ridb\_core.d.ts:880
 
 #### Parameters
 
@@ -1738,7 +1738,7 @@ Defined in: ridb\_core.d.ts:990
 
 > `readonly` **corestorage\_matchesQuery**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:992
+Defined in: ridb\_core.d.ts:882
 
 #### Parameters
 
@@ -1768,7 +1768,7 @@ Defined in: ridb\_core.d.ts:992
 
 > `readonly` **corestorage\_new**: () => `number`
 
-Defined in: ridb\_core.d.ts:1007
+Defined in: ridb\_core.d.ts:890
 
 #### Returns
 
@@ -1780,7 +1780,7 @@ Defined in: ridb\_core.d.ts:1007
 
 > `readonly` **database\_authenticate**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:997
+Defined in: ridb\_core.d.ts:902
 
 #### Parameters
 
@@ -1806,7 +1806,7 @@ Defined in: ridb\_core.d.ts:997
 
 > `readonly` **database\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:995
+Defined in: ridb\_core.d.ts:900
 
 #### Parameters
 
@@ -1824,7 +1824,7 @@ Defined in: ridb\_core.d.ts:995
 
 > `readonly` **database\_collections**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:998
+Defined in: ridb\_core.d.ts:903
 
 #### Parameters
 
@@ -1846,7 +1846,7 @@ Defined in: ridb\_core.d.ts:998
 
 > `readonly` **database\_create**: (`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`) => `number`
 
-Defined in: ridb\_core.d.ts:999
+Defined in: ridb\_core.d.ts:904
 
 #### Parameters
 
@@ -1896,7 +1896,7 @@ Defined in: ridb\_core.d.ts:999
 
 > `readonly` **database\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:994
+Defined in: ridb\_core.d.ts:899
 
 #### Parameters
 
@@ -1914,7 +1914,7 @@ Defined in: ridb\_core.d.ts:994
 
 > `readonly` **database\_started**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:996
+Defined in: ridb\_core.d.ts:901
 
 #### Parameters
 
@@ -1932,7 +1932,7 @@ Defined in: ridb\_core.d.ts:996
 
 > `readonly` **indexdb\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:908
+Defined in: ridb\_core.d.ts:1007
 
 #### Parameters
 
@@ -1950,7 +1950,7 @@ Defined in: ridb\_core.d.ts:908
 
 > `readonly` **indexdb\_count**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:907
+Defined in: ridb\_core.d.ts:1006
 
 #### Parameters
 
@@ -1984,7 +1984,7 @@ Defined in: ridb\_core.d.ts:907
 
 > `readonly` **indexdb\_create**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:903
+Defined in: ridb\_core.d.ts:1002
 
 #### Parameters
 
@@ -2010,7 +2010,7 @@ Defined in: ridb\_core.d.ts:903
 
 > `readonly` **indexdb\_find**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:905
+Defined in: ridb\_core.d.ts:1004
 
 #### Parameters
 
@@ -2044,7 +2044,7 @@ Defined in: ridb\_core.d.ts:905
 
 > `readonly` **indexdb\_findDocumentById**: (`a`, `b`, `c`, `d`) => `number`
 
-Defined in: ridb\_core.d.ts:906
+Defined in: ridb\_core.d.ts:1005
 
 #### Parameters
 
@@ -2074,7 +2074,7 @@ Defined in: ridb\_core.d.ts:906
 
 > `readonly` **indexdb\_get\_store**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:902
+Defined in: ridb\_core.d.ts:1001
 
 #### Parameters
 
@@ -2104,7 +2104,7 @@ Defined in: ridb\_core.d.ts:902
 
 > `readonly` **indexdb\_get\_stores**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:901
+Defined in: ridb\_core.d.ts:1000
 
 #### Parameters
 
@@ -2126,7 +2126,7 @@ Defined in: ridb\_core.d.ts:901
 
 > `readonly` **indexdb\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:909
+Defined in: ridb\_core.d.ts:1008
 
 #### Parameters
 
@@ -2144,7 +2144,7 @@ Defined in: ridb\_core.d.ts:909
 
 > `readonly` **indexdb\_write**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:904
+Defined in: ridb\_core.d.ts:1003
 
 #### Parameters
 
@@ -2166,7 +2166,7 @@ Defined in: ridb\_core.d.ts:904
 
 > `readonly` **inmemory\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:988
+Defined in: ridb\_core.d.ts:958
 
 #### Parameters
 
@@ -2184,7 +2184,7 @@ Defined in: ridb\_core.d.ts:988
 
 > `readonly` **inmemory\_count**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:987
+Defined in: ridb\_core.d.ts:957
 
 #### Parameters
 
@@ -2218,7 +2218,7 @@ Defined in: ridb\_core.d.ts:987
 
 > `readonly` **inmemory\_create**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:983
+Defined in: ridb\_core.d.ts:953
 
 #### Parameters
 
@@ -2244,7 +2244,7 @@ Defined in: ridb\_core.d.ts:983
 
 > `readonly` **inmemory\_find**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:985
+Defined in: ridb\_core.d.ts:955
 
 #### Parameters
 
@@ -2278,7 +2278,7 @@ Defined in: ridb\_core.d.ts:985
 
 > `readonly` **inmemory\_findDocumentById**: (`a`, `b`, `c`, `d`) => `number`
 
-Defined in: ridb\_core.d.ts:986
+Defined in: ridb\_core.d.ts:956
 
 #### Parameters
 
@@ -2308,7 +2308,7 @@ Defined in: ridb\_core.d.ts:986
 
 > `readonly` **inmemory\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:989
+Defined in: ridb\_core.d.ts:959
 
 #### Parameters
 
@@ -2326,7 +2326,7 @@ Defined in: ridb\_core.d.ts:989
 
 > `readonly` **inmemory\_write**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:984
+Defined in: ridb\_core.d.ts:954
 
 #### Parameters
 
@@ -2348,7 +2348,7 @@ Defined in: ridb\_core.d.ts:984
 
 > `readonly` **is\_debug\_mode**: () => `number`
 
-Defined in: ridb\_core.d.ts:887
+Defined in: ridb\_core.d.ts:961
 
 #### Returns
 
@@ -2360,7 +2360,7 @@ Defined in: ridb\_core.d.ts:887
 
 > `readonly` **main\_js**: () => `void`
 
-Defined in: ridb\_core.d.ts:886
+Defined in: ridb\_core.d.ts:960
 
 #### Returns
 
@@ -2380,7 +2380,7 @@ Defined in: ridb\_core.d.ts:869
 
 > `readonly` **operation\_collection**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1001
+Defined in: ridb\_core.d.ts:884
 
 #### Parameters
 
@@ -2402,7 +2402,7 @@ Defined in: ridb\_core.d.ts:1001
 
 > `readonly` **operation\_data**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1003
+Defined in: ridb\_core.d.ts:886
 
 #### Parameters
 
@@ -2420,7 +2420,7 @@ Defined in: ridb\_core.d.ts:1003
 
 > `readonly` **operation\_opType**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1002
+Defined in: ridb\_core.d.ts:885
 
 #### Parameters
 
@@ -2438,7 +2438,7 @@ Defined in: ridb\_core.d.ts:1002
 
 > `readonly` **operation\_primaryKey**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1005
+Defined in: ridb\_core.d.ts:888
 
 #### Parameters
 
@@ -2456,7 +2456,7 @@ Defined in: ridb\_core.d.ts:1005
 
 > `readonly` **operation\_primaryKeyField**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1004
+Defined in: ridb\_core.d.ts:887
 
 #### Parameters
 
@@ -2474,7 +2474,7 @@ Defined in: ridb\_core.d.ts:1004
 
 > `readonly` **operation\_primaryKeyIndex**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1006
+Defined in: ridb\_core.d.ts:889
 
 #### Parameters
 
@@ -2496,7 +2496,7 @@ Defined in: ridb\_core.d.ts:1006
 
 > `readonly` **property\_is\_valid**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:951
+Defined in: ridb\_core.d.ts:988
 
 #### Parameters
 
@@ -2518,7 +2518,7 @@ Defined in: ridb\_core.d.ts:951
 
 > `readonly` **property\_items**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:953
+Defined in: ridb\_core.d.ts:990
 
 #### Parameters
 
@@ -2540,7 +2540,7 @@ Defined in: ridb\_core.d.ts:953
 
 > `readonly` **property\_maxItems**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:954
+Defined in: ridb\_core.d.ts:991
 
 #### Parameters
 
@@ -2562,7 +2562,7 @@ Defined in: ridb\_core.d.ts:954
 
 > `readonly` **property\_maxLength**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:956
+Defined in: ridb\_core.d.ts:993
 
 #### Parameters
 
@@ -2584,7 +2584,7 @@ Defined in: ridb\_core.d.ts:956
 
 > `readonly` **property\_minItems**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:955
+Defined in: ridb\_core.d.ts:992
 
 #### Parameters
 
@@ -2606,7 +2606,7 @@ Defined in: ridb\_core.d.ts:955
 
 > `readonly` **property\_minLength**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:957
+Defined in: ridb\_core.d.ts:994
 
 #### Parameters
 
@@ -2628,7 +2628,7 @@ Defined in: ridb\_core.d.ts:957
 
 > `readonly` **property\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:958
+Defined in: ridb\_core.d.ts:995
 
 #### Parameters
 
@@ -2650,7 +2650,7 @@ Defined in: ridb\_core.d.ts:958
 
 > `readonly` **property\_type**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:952
+Defined in: ridb\_core.d.ts:989
 
 #### Parameters
 
@@ -2668,7 +2668,7 @@ Defined in: ridb\_core.d.ts:952
 
 > `readonly` **query\_get**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:919
+Defined in: ridb\_core.d.ts:921
 
 #### Parameters
 
@@ -2698,7 +2698,7 @@ Defined in: ridb\_core.d.ts:919
 
 > `readonly` **query\_get\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:916
+Defined in: ridb\_core.d.ts:918
 
 #### Parameters
 
@@ -2720,7 +2720,7 @@ Defined in: ridb\_core.d.ts:916
 
 > `readonly` **query\_has\_or\_operator**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:920
+Defined in: ridb\_core.d.ts:922
 
 #### Parameters
 
@@ -2738,7 +2738,7 @@ Defined in: ridb\_core.d.ts:920
 
 > `readonly` **query\_new**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:914
+Defined in: ridb\_core.d.ts:916
 
 #### Parameters
 
@@ -2764,7 +2764,7 @@ Defined in: ridb\_core.d.ts:914
 
 > `readonly` **query\_parse**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:917
+Defined in: ridb\_core.d.ts:919
 
 #### Parameters
 
@@ -2786,7 +2786,7 @@ Defined in: ridb\_core.d.ts:917
 
 > `readonly` **query\_process\_query**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:918
+Defined in: ridb\_core.d.ts:920
 
 #### Parameters
 
@@ -2812,7 +2812,7 @@ Defined in: ridb\_core.d.ts:918
 
 > `readonly` **query\_query**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:915
+Defined in: ridb\_core.d.ts:917
 
 #### Parameters
 
@@ -2834,7 +2834,7 @@ Defined in: ridb\_core.d.ts:915
 
 > `readonly` **queryoptions\_limit**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:911
+Defined in: ridb\_core.d.ts:906
 
 #### Parameters
 
@@ -2856,7 +2856,7 @@ Defined in: ridb\_core.d.ts:911
 
 > `readonly` **queryoptions\_offset**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:912
+Defined in: ridb\_core.d.ts:907
 
 #### Parameters
 
@@ -2878,7 +2878,7 @@ Defined in: ridb\_core.d.ts:912
 
 > `readonly` **ridberror\_authentication**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:896
+Defined in: ridb\_core.d.ts:970
 
 #### Parameters
 
@@ -2904,7 +2904,7 @@ Defined in: ridb\_core.d.ts:896
 
 > `readonly` **ridberror\_code**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:891
+Defined in: ridb\_core.d.ts:965
 
 #### Parameters
 
@@ -2922,7 +2922,7 @@ Defined in: ridb\_core.d.ts:891
 
 > `readonly` **ridberror\_error**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:894
+Defined in: ridb\_core.d.ts:968
 
 #### Parameters
 
@@ -2948,7 +2948,7 @@ Defined in: ridb\_core.d.ts:894
 
 > `readonly` **ridberror\_from**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:893
+Defined in: ridb\_core.d.ts:967
 
 #### Parameters
 
@@ -2966,7 +2966,7 @@ Defined in: ridb\_core.d.ts:893
 
 > `readonly` **ridberror\_hook**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:899
+Defined in: ridb\_core.d.ts:973
 
 #### Parameters
 
@@ -2992,7 +2992,7 @@ Defined in: ridb\_core.d.ts:899
 
 > `readonly` **ridberror\_message**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:892
+Defined in: ridb\_core.d.ts:966
 
 #### Parameters
 
@@ -3014,7 +3014,7 @@ Defined in: ridb\_core.d.ts:892
 
 > `readonly` **ridberror\_new**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:889
+Defined in: ridb\_core.d.ts:963
 
 #### Parameters
 
@@ -3048,7 +3048,7 @@ Defined in: ridb\_core.d.ts:889
 
 > `readonly` **ridberror\_query**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:895
+Defined in: ridb\_core.d.ts:969
 
 #### Parameters
 
@@ -3074,7 +3074,7 @@ Defined in: ridb\_core.d.ts:895
 
 > `readonly` **ridberror\_serialisation**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:897
+Defined in: ridb\_core.d.ts:971
 
 #### Parameters
 
@@ -3100,7 +3100,7 @@ Defined in: ridb\_core.d.ts:897
 
 > `readonly` **ridberror\_type**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:890
+Defined in: ridb\_core.d.ts:964
 
 #### Parameters
 
@@ -3122,7 +3122,7 @@ Defined in: ridb\_core.d.ts:890
 
 > `readonly` **ridberror\_validation**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:898
+Defined in: ridb\_core.d.ts:972
 
 #### Parameters
 
@@ -3148,7 +3148,7 @@ Defined in: ridb\_core.d.ts:898
 
 > `readonly` **schema\_create**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:965
+Defined in: ridb\_core.d.ts:977
 
 #### Parameters
 
@@ -3170,7 +3170,7 @@ Defined in: ridb\_core.d.ts:965
 
 > `readonly` **schema\_encrypted**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:970
+Defined in: ridb\_core.d.ts:982
 
 #### Parameters
 
@@ -3192,7 +3192,7 @@ Defined in: ridb\_core.d.ts:970
 
 > `readonly` **schema\_indexes**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:969
+Defined in: ridb\_core.d.ts:981
 
 #### Parameters
 
@@ -3214,7 +3214,7 @@ Defined in: ridb\_core.d.ts:969
 
 > `readonly` **schema\_is\_valid**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:964
+Defined in: ridb\_core.d.ts:976
 
 #### Parameters
 
@@ -3236,7 +3236,7 @@ Defined in: ridb\_core.d.ts:964
 
 > `readonly` **schema\_primaryKey**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:967
+Defined in: ridb\_core.d.ts:979
 
 #### Parameters
 
@@ -3258,7 +3258,7 @@ Defined in: ridb\_core.d.ts:967
 
 > `readonly` **schema\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:971
+Defined in: ridb\_core.d.ts:983
 
 #### Parameters
 
@@ -3280,7 +3280,7 @@ Defined in: ridb\_core.d.ts:971
 
 > `readonly` **schema\_type**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:968
+Defined in: ridb\_core.d.ts:980
 
 #### Parameters
 
@@ -3302,7 +3302,7 @@ Defined in: ridb\_core.d.ts:968
 
 > `readonly` **schema\_validate**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:963
+Defined in: ridb\_core.d.ts:975
 
 #### Parameters
 
@@ -3328,7 +3328,7 @@ Defined in: ridb\_core.d.ts:963
 
 > `readonly` **schema\_version**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:966
+Defined in: ridb\_core.d.ts:978
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/interfaces/InitOutput.md
+++ b/docs/@trust0/ridb-core/interfaces/InitOutput.md
@@ -14,7 +14,7 @@ Defined in: ridb\_core.d.ts:868
 
 > `readonly` **\_\_wbg\_baseplugin\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:908
+Defined in: ridb\_core.d.ts:977
 
 #### Parameters
 
@@ -32,7 +32,7 @@ Defined in: ridb\_core.d.ts:908
 
 > `readonly` **\_\_wbg\_basestorage\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:892
+Defined in: ridb\_core.d.ts:961
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: ridb\_core.d.ts:892
 
 > `readonly` **\_\_wbg\_collection\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:870
+Defined in: ridb\_core.d.ts:892
 
 #### Parameters
 
@@ -68,7 +68,7 @@ Defined in: ridb\_core.d.ts:870
 
 > `readonly` **\_\_wbg\_corestorage\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:891
+Defined in: ridb\_core.d.ts:913
 
 #### Parameters
 
@@ -86,7 +86,7 @@ Defined in: ridb\_core.d.ts:891
 
 > `readonly` **\_\_wbg\_database\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:898
+Defined in: ridb\_core.d.ts:967
 
 #### Parameters
 
@@ -104,7 +104,7 @@ Defined in: ridb\_core.d.ts:898
 
 > `readonly` **\_\_wbg\_indexdb\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:999
+Defined in: ridb\_core.d.ts:882
 
 #### Parameters
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:999
 
 > `readonly` **\_\_wbg\_inmemory\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:952
+Defined in: ridb\_core.d.ts:951
 
 #### Parameters
 
@@ -140,7 +140,7 @@ Defined in: ridb\_core.d.ts:952
 
 > `readonly` **\_\_wbg\_operation\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:883
+Defined in: ridb\_core.d.ts:905
 
 #### Parameters
 
@@ -158,7 +158,7 @@ Defined in: ridb\_core.d.ts:883
 
 > `readonly` **\_\_wbg\_property\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:987
+Defined in: ridb\_core.d.ts:870
 
 #### Parameters
 
@@ -176,7 +176,7 @@ Defined in: ridb\_core.d.ts:987
 
 > `readonly` **\_\_wbg\_query\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:915
+Defined in: ridb\_core.d.ts:914
 
 #### Parameters
 
@@ -194,7 +194,7 @@ Defined in: ridb\_core.d.ts:915
 
 > `readonly` **\_\_wbg\_queryoptions\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:905
+Defined in: ridb\_core.d.ts:974
 
 #### Parameters
 
@@ -212,7 +212,7 @@ Defined in: ridb\_core.d.ts:905
 
 > `readonly` **\_\_wbg\_ridberror\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:962
+Defined in: ridb\_core.d.ts:984
 
 #### Parameters
 
@@ -230,7 +230,7 @@ Defined in: ridb\_core.d.ts:962
 
 > `readonly` **\_\_wbg\_schema\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:974
+Defined in: ridb\_core.d.ts:996
 
 #### Parameters
 
@@ -266,7 +266,7 @@ Defined in: ridb\_core.d.ts:1009
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_array\_values\_10**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:927
+Defined in: ridb\_core.d.ts:926
 
 #### Parameters
 
@@ -284,7 +284,7 @@ Defined in: ridb\_core.d.ts:927
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_deeply\_nested\_12**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:929
+Defined in: ridb\_core.d.ts:928
 
 #### Parameters
 
@@ -302,7 +302,7 @@ Defined in: ridb\_core.d.ts:929
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_empty\_query\_11**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:928
+Defined in: ridb\_core.d.ts:927
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:928
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_nested\_operators\_9**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:926
+Defined in: ridb\_core.d.ts:925
 
 #### Parameters
 
@@ -338,7 +338,7 @@ Defined in: ridb\_core.d.ts:926
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_simple\_fields\_6**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:923
+Defined in: ridb\_core.d.ts:922
 
 #### Parameters
 
@@ -356,7 +356,7 @@ Defined in: ridb\_core.d.ts:923
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_array\_at\_top\_level\_14**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:931
+Defined in: ridb\_core.d.ts:930
 
 #### Parameters
 
@@ -374,7 +374,7 @@ Defined in: ridb\_core.d.ts:931
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_logical\_operators\_8**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:925
+Defined in: ridb\_core.d.ts:924
 
 #### Parameters
 
@@ -392,7 +392,7 @@ Defined in: ridb\_core.d.ts:925
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_multiple\_same\_props\_13**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:930
+Defined in: ridb\_core.d.ts:929
 
 #### Parameters
 
@@ -410,7 +410,7 @@ Defined in: ridb\_core.d.ts:930
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_operators\_7**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:924
+Defined in: ridb\_core.d.ts:923
 
 #### Parameters
 
@@ -428,7 +428,7 @@ Defined in: ridb\_core.d.ts:924
 
 > `readonly` **\_\_wbgt\_test\_invalid\_property\_2**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:998
+Defined in: ridb\_core.d.ts:881
 
 #### Parameters
 
@@ -446,7 +446,7 @@ Defined in: ridb\_core.d.ts:998
 
 > `readonly` **\_\_wbgt\_test\_invalid\_schema\_5**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:986
+Defined in: ridb\_core.d.ts:1008
 
 #### Parameters
 
@@ -464,7 +464,7 @@ Defined in: ridb\_core.d.ts:986
 
 > `readonly` **\_\_wbgt\_test\_property\_creation\_0**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:996
+Defined in: ridb\_core.d.ts:879
 
 #### Parameters
 
@@ -482,7 +482,7 @@ Defined in: ridb\_core.d.ts:996
 
 > `readonly` **\_\_wbgt\_test\_property\_validation\_1**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:997
+Defined in: ridb\_core.d.ts:880
 
 #### Parameters
 
@@ -500,7 +500,7 @@ Defined in: ridb\_core.d.ts:997
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_complex\_mixed\_22**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:939
+Defined in: ridb\_core.d.ts:938
 
 #### Parameters
 
@@ -518,7 +518,7 @@ Defined in: ridb\_core.d.ts:939
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_nested\_logical\_operators\_20**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:937
+Defined in: ridb\_core.d.ts:936
 
 #### Parameters
 
@@ -536,7 +536,7 @@ Defined in: ridb\_core.d.ts:937
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_only\_logical\_operator\_21**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:938
+Defined in: ridb\_core.d.ts:937
 
 #### Parameters
 
@@ -554,7 +554,7 @@ Defined in: ridb\_core.d.ts:938
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_simple\_attributes\_18**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:935
+Defined in: ridb\_core.d.ts:934
 
 #### Parameters
 
@@ -572,7 +572,7 @@ Defined in: ridb\_core.d.ts:935
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_with\_logical\_operator\_19**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:936
+Defined in: ridb\_core.d.ts:935
 
 #### Parameters
 
@@ -590,7 +590,7 @@ Defined in: ridb\_core.d.ts:936
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_age\_query\_24**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:941
+Defined in: ridb\_core.d.ts:940
 
 #### Parameters
 
@@ -608,7 +608,7 @@ Defined in: ridb\_core.d.ts:941
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_empty\_logical\_operators\_28**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:945
+Defined in: ridb\_core.d.ts:944
 
 #### Parameters
 
@@ -626,7 +626,7 @@ Defined in: ridb\_core.d.ts:945
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_empty\_query\_23**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:940
+Defined in: ridb\_core.d.ts:939
 
 #### Parameters
 
@@ -644,7 +644,7 @@ Defined in: ridb\_core.d.ts:940
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_eq\_operator\_31**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:948
+Defined in: ridb\_core.d.ts:947
 
 #### Parameters
 
@@ -662,7 +662,7 @@ Defined in: ridb\_core.d.ts:948
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_eq\_operator\_wrong\_type\_32**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:949
+Defined in: ridb\_core.d.ts:948
 
 #### Parameters
 
@@ -680,7 +680,7 @@ Defined in: ridb\_core.d.ts:949
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_in\_operator\_16**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:933
+Defined in: ridb\_core.d.ts:932
 
 #### Parameters
 
@@ -698,7 +698,7 @@ Defined in: ridb\_core.d.ts:933
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_in\_operator\_wrong\_type\_17**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:934
+Defined in: ridb\_core.d.ts:933
 
 #### Parameters
 
@@ -716,7 +716,7 @@ Defined in: ridb\_core.d.ts:934
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_invalid\_in\_operator\_27**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:944
+Defined in: ridb\_core.d.ts:943
 
 #### Parameters
 
@@ -734,7 +734,7 @@ Defined in: ridb\_core.d.ts:944
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_multiple\_operators\_26**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:943
+Defined in: ridb\_core.d.ts:942
 
 #### Parameters
 
@@ -752,7 +752,7 @@ Defined in: ridb\_core.d.ts:943
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_ne\_operator\_33**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:950
+Defined in: ridb\_core.d.ts:949
 
 #### Parameters
 
@@ -770,7 +770,7 @@ Defined in: ridb\_core.d.ts:950
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_ne\_operator\_wrong\_type\_34**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:951
+Defined in: ridb\_core.d.ts:950
 
 #### Parameters
 
@@ -788,7 +788,7 @@ Defined in: ridb\_core.d.ts:951
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_nin\_operator\_29**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:946
+Defined in: ridb\_core.d.ts:945
 
 #### Parameters
 
@@ -806,7 +806,7 @@ Defined in: ridb\_core.d.ts:946
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_nin\_operator\_wrong\_type\_30**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:947
+Defined in: ridb\_core.d.ts:946
 
 #### Parameters
 
@@ -824,7 +824,7 @@ Defined in: ridb\_core.d.ts:947
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_non\_object\_query\_25**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:942
+Defined in: ridb\_core.d.ts:941
 
 #### Parameters
 
@@ -842,7 +842,7 @@ Defined in: ridb\_core.d.ts:942
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_operator\_wrong\_type\_15**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:932
+Defined in: ridb\_core.d.ts:931
 
 #### Parameters
 
@@ -860,7 +860,7 @@ Defined in: ridb\_core.d.ts:932
 
 > `readonly` **\_\_wbgt\_test\_schema\_creation\_3**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:984
+Defined in: ridb\_core.d.ts:1006
 
 #### Parameters
 
@@ -878,7 +878,7 @@ Defined in: ridb\_core.d.ts:984
 
 > `readonly` **\_\_wbgt\_test\_schema\_validation\_4**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:985
+Defined in: ridb\_core.d.ts:1007
 
 #### Parameters
 
@@ -1210,7 +1210,7 @@ Defined in: ridb\_core.d.ts:1021
 
 > `readonly` **baseplugin\_get\_doc\_create\_hook**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:911
+Defined in: ridb\_core.d.ts:980
 
 #### Parameters
 
@@ -1228,7 +1228,7 @@ Defined in: ridb\_core.d.ts:911
 
 > `readonly` **baseplugin\_get\_doc\_recover\_hook**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:912
+Defined in: ridb\_core.d.ts:981
 
 #### Parameters
 
@@ -1246,7 +1246,7 @@ Defined in: ridb\_core.d.ts:912
 
 > `readonly` **baseplugin\_name**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:910
+Defined in: ridb\_core.d.ts:979
 
 #### Parameters
 
@@ -1264,7 +1264,7 @@ Defined in: ridb\_core.d.ts:910
 
 > `readonly` **baseplugin\_new**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:909
+Defined in: ridb\_core.d.ts:978
 
 #### Parameters
 
@@ -1290,7 +1290,7 @@ Defined in: ridb\_core.d.ts:909
 
 > `readonly` **baseplugin\_set\_doc\_create\_hook**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:913
+Defined in: ridb\_core.d.ts:982
 
 #### Parameters
 
@@ -1312,7 +1312,7 @@ Defined in: ridb\_core.d.ts:913
 
 > `readonly` **baseplugin\_set\_doc\_recover\_hook**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:914
+Defined in: ridb\_core.d.ts:983
 
 #### Parameters
 
@@ -1334,7 +1334,7 @@ Defined in: ridb\_core.d.ts:914
 
 > `readonly` **basestorage\_addIndexSchemas**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:894
+Defined in: ridb\_core.d.ts:963
 
 #### Parameters
 
@@ -1356,7 +1356,7 @@ Defined in: ridb\_core.d.ts:894
 
 > `readonly` **basestorage\_core**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:897
+Defined in: ridb\_core.d.ts:966
 
 #### Parameters
 
@@ -1378,7 +1378,7 @@ Defined in: ridb\_core.d.ts:897
 
 > `readonly` **basestorage\_getOption**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:895
+Defined in: ridb\_core.d.ts:964
 
 #### Parameters
 
@@ -1408,7 +1408,7 @@ Defined in: ridb\_core.d.ts:895
 
 > `readonly` **basestorage\_getSchema**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:896
+Defined in: ridb\_core.d.ts:965
 
 #### Parameters
 
@@ -1438,7 +1438,7 @@ Defined in: ridb\_core.d.ts:896
 
 > `readonly` **basestorage\_new**: (`a`, `b`, `c`, `d`, `e`) => `void`
 
-Defined in: ridb\_core.d.ts:893
+Defined in: ridb\_core.d.ts:962
 
 #### Parameters
 
@@ -1472,7 +1472,7 @@ Defined in: ridb\_core.d.ts:893
 
 > `readonly` **collection\_count**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:875
+Defined in: ridb\_core.d.ts:897
 
 #### Parameters
 
@@ -1498,7 +1498,7 @@ Defined in: ridb\_core.d.ts:875
 
 > `readonly` **collection\_create**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:878
+Defined in: ridb\_core.d.ts:900
 
 #### Parameters
 
@@ -1520,7 +1520,7 @@ Defined in: ridb\_core.d.ts:878
 
 > `readonly` **collection\_delete**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:879
+Defined in: ridb\_core.d.ts:901
 
 #### Parameters
 
@@ -1542,7 +1542,7 @@ Defined in: ridb\_core.d.ts:879
 
 > `readonly` **collection\_find**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:873
+Defined in: ridb\_core.d.ts:895
 
 #### Parameters
 
@@ -1568,7 +1568,7 @@ Defined in: ridb\_core.d.ts:873
 
 > `readonly` **collection\_findById**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:876
+Defined in: ridb\_core.d.ts:898
 
 #### Parameters
 
@@ -1590,7 +1590,7 @@ Defined in: ridb\_core.d.ts:876
 
 > `readonly` **collection\_name**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:871
+Defined in: ridb\_core.d.ts:893
 
 #### Parameters
 
@@ -1612,7 +1612,7 @@ Defined in: ridb\_core.d.ts:871
 
 > `readonly` **collection\_parse\_query\_options**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:874
+Defined in: ridb\_core.d.ts:896
 
 #### Parameters
 
@@ -1638,7 +1638,7 @@ Defined in: ridb\_core.d.ts:874
 
 > `readonly` **collection\_schema**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:872
+Defined in: ridb\_core.d.ts:894
 
 #### Parameters
 
@@ -1660,7 +1660,7 @@ Defined in: ridb\_core.d.ts:872
 
 > `readonly` **collection\_update**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:877
+Defined in: ridb\_core.d.ts:899
 
 #### Parameters
 
@@ -1682,7 +1682,7 @@ Defined in: ridb\_core.d.ts:877
 
 > `readonly` **corestorage\_getIndexes**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:881
+Defined in: ridb\_core.d.ts:903
 
 #### Parameters
 
@@ -1712,7 +1712,7 @@ Defined in: ridb\_core.d.ts:881
 
 > `readonly` **corestorage\_getPrimaryKeyTyped**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:880
+Defined in: ridb\_core.d.ts:902
 
 #### Parameters
 
@@ -1738,7 +1738,7 @@ Defined in: ridb\_core.d.ts:880
 
 > `readonly` **corestorage\_matchesQuery**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:882
+Defined in: ridb\_core.d.ts:904
 
 #### Parameters
 
@@ -1768,7 +1768,7 @@ Defined in: ridb\_core.d.ts:882
 
 > `readonly` **corestorage\_new**: () => `number`
 
-Defined in: ridb\_core.d.ts:890
+Defined in: ridb\_core.d.ts:912
 
 #### Returns
 
@@ -1780,7 +1780,7 @@ Defined in: ridb\_core.d.ts:890
 
 > `readonly` **database\_authenticate**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:902
+Defined in: ridb\_core.d.ts:971
 
 #### Parameters
 
@@ -1806,7 +1806,7 @@ Defined in: ridb\_core.d.ts:902
 
 > `readonly` **database\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:900
+Defined in: ridb\_core.d.ts:969
 
 #### Parameters
 
@@ -1824,7 +1824,7 @@ Defined in: ridb\_core.d.ts:900
 
 > `readonly` **database\_collections**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:903
+Defined in: ridb\_core.d.ts:972
 
 #### Parameters
 
@@ -1846,7 +1846,7 @@ Defined in: ridb\_core.d.ts:903
 
 > `readonly` **database\_create**: (`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`) => `number`
 
-Defined in: ridb\_core.d.ts:904
+Defined in: ridb\_core.d.ts:973
 
 #### Parameters
 
@@ -1896,7 +1896,7 @@ Defined in: ridb\_core.d.ts:904
 
 > `readonly` **database\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:899
+Defined in: ridb\_core.d.ts:968
 
 #### Parameters
 
@@ -1914,7 +1914,7 @@ Defined in: ridb\_core.d.ts:899
 
 > `readonly` **database\_started**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:901
+Defined in: ridb\_core.d.ts:970
 
 #### Parameters
 
@@ -1932,7 +1932,7 @@ Defined in: ridb\_core.d.ts:901
 
 > `readonly` **indexdb\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1007
+Defined in: ridb\_core.d.ts:890
 
 #### Parameters
 
@@ -1950,7 +1950,7 @@ Defined in: ridb\_core.d.ts:1007
 
 > `readonly` **indexdb\_count**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:1006
+Defined in: ridb\_core.d.ts:889
 
 #### Parameters
 
@@ -1984,7 +1984,7 @@ Defined in: ridb\_core.d.ts:1006
 
 > `readonly` **indexdb\_create**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:1002
+Defined in: ridb\_core.d.ts:885
 
 #### Parameters
 
@@ -2010,7 +2010,7 @@ Defined in: ridb\_core.d.ts:1002
 
 > `readonly` **indexdb\_find**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:1004
+Defined in: ridb\_core.d.ts:887
 
 #### Parameters
 
@@ -2044,7 +2044,7 @@ Defined in: ridb\_core.d.ts:1004
 
 > `readonly` **indexdb\_findDocumentById**: (`a`, `b`, `c`, `d`) => `number`
 
-Defined in: ridb\_core.d.ts:1005
+Defined in: ridb\_core.d.ts:888
 
 #### Parameters
 
@@ -2074,7 +2074,7 @@ Defined in: ridb\_core.d.ts:1005
 
 > `readonly` **indexdb\_get\_store**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:1001
+Defined in: ridb\_core.d.ts:884
 
 #### Parameters
 
@@ -2104,7 +2104,7 @@ Defined in: ridb\_core.d.ts:1001
 
 > `readonly` **indexdb\_get\_stores**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1000
+Defined in: ridb\_core.d.ts:883
 
 #### Parameters
 
@@ -2126,7 +2126,7 @@ Defined in: ridb\_core.d.ts:1000
 
 > `readonly` **indexdb\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1008
+Defined in: ridb\_core.d.ts:891
 
 #### Parameters
 
@@ -2144,7 +2144,7 @@ Defined in: ridb\_core.d.ts:1008
 
 > `readonly` **indexdb\_write**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:1003
+Defined in: ridb\_core.d.ts:886
 
 #### Parameters
 
@@ -2166,7 +2166,7 @@ Defined in: ridb\_core.d.ts:1003
 
 > `readonly` **inmemory\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:958
+Defined in: ridb\_core.d.ts:957
 
 #### Parameters
 
@@ -2184,7 +2184,7 @@ Defined in: ridb\_core.d.ts:958
 
 > `readonly` **inmemory\_count**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:957
+Defined in: ridb\_core.d.ts:956
 
 #### Parameters
 
@@ -2218,7 +2218,7 @@ Defined in: ridb\_core.d.ts:957
 
 > `readonly` **inmemory\_create**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:953
+Defined in: ridb\_core.d.ts:952
 
 #### Parameters
 
@@ -2244,7 +2244,7 @@ Defined in: ridb\_core.d.ts:953
 
 > `readonly` **inmemory\_find**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:955
+Defined in: ridb\_core.d.ts:954
 
 #### Parameters
 
@@ -2278,7 +2278,7 @@ Defined in: ridb\_core.d.ts:955
 
 > `readonly` **inmemory\_findDocumentById**: (`a`, `b`, `c`, `d`) => `number`
 
-Defined in: ridb\_core.d.ts:956
+Defined in: ridb\_core.d.ts:955
 
 #### Parameters
 
@@ -2308,7 +2308,7 @@ Defined in: ridb\_core.d.ts:956
 
 > `readonly` **inmemory\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:959
+Defined in: ridb\_core.d.ts:958
 
 #### Parameters
 
@@ -2326,7 +2326,7 @@ Defined in: ridb\_core.d.ts:959
 
 > `readonly` **inmemory\_write**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:954
+Defined in: ridb\_core.d.ts:953
 
 #### Parameters
 
@@ -2348,7 +2348,7 @@ Defined in: ridb\_core.d.ts:954
 
 > `readonly` **is\_debug\_mode**: () => `number`
 
-Defined in: ridb\_core.d.ts:961
+Defined in: ridb\_core.d.ts:960
 
 #### Returns
 
@@ -2360,7 +2360,7 @@ Defined in: ridb\_core.d.ts:961
 
 > `readonly` **main\_js**: () => `void`
 
-Defined in: ridb\_core.d.ts:960
+Defined in: ridb\_core.d.ts:959
 
 #### Returns
 
@@ -2380,7 +2380,7 @@ Defined in: ridb\_core.d.ts:869
 
 > `readonly` **operation\_collection**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:884
+Defined in: ridb\_core.d.ts:906
 
 #### Parameters
 
@@ -2402,7 +2402,7 @@ Defined in: ridb\_core.d.ts:884
 
 > `readonly` **operation\_data**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:886
+Defined in: ridb\_core.d.ts:908
 
 #### Parameters
 
@@ -2420,7 +2420,7 @@ Defined in: ridb\_core.d.ts:886
 
 > `readonly` **operation\_opType**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:885
+Defined in: ridb\_core.d.ts:907
 
 #### Parameters
 
@@ -2438,7 +2438,7 @@ Defined in: ridb\_core.d.ts:885
 
 > `readonly` **operation\_primaryKey**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:888
+Defined in: ridb\_core.d.ts:910
 
 #### Parameters
 
@@ -2456,7 +2456,7 @@ Defined in: ridb\_core.d.ts:888
 
 > `readonly` **operation\_primaryKeyField**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:887
+Defined in: ridb\_core.d.ts:909
 
 #### Parameters
 
@@ -2474,7 +2474,7 @@ Defined in: ridb\_core.d.ts:887
 
 > `readonly` **operation\_primaryKeyIndex**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:889
+Defined in: ridb\_core.d.ts:911
 
 #### Parameters
 
@@ -2496,7 +2496,7 @@ Defined in: ridb\_core.d.ts:889
 
 > `readonly` **property\_is\_valid**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:988
+Defined in: ridb\_core.d.ts:871
 
 #### Parameters
 
@@ -2518,7 +2518,7 @@ Defined in: ridb\_core.d.ts:988
 
 > `readonly` **property\_items**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:990
+Defined in: ridb\_core.d.ts:873
 
 #### Parameters
 
@@ -2540,7 +2540,7 @@ Defined in: ridb\_core.d.ts:990
 
 > `readonly` **property\_maxItems**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:991
+Defined in: ridb\_core.d.ts:874
 
 #### Parameters
 
@@ -2562,7 +2562,7 @@ Defined in: ridb\_core.d.ts:991
 
 > `readonly` **property\_maxLength**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:993
+Defined in: ridb\_core.d.ts:876
 
 #### Parameters
 
@@ -2584,7 +2584,7 @@ Defined in: ridb\_core.d.ts:993
 
 > `readonly` **property\_minItems**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:992
+Defined in: ridb\_core.d.ts:875
 
 #### Parameters
 
@@ -2606,7 +2606,7 @@ Defined in: ridb\_core.d.ts:992
 
 > `readonly` **property\_minLength**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:994
+Defined in: ridb\_core.d.ts:877
 
 #### Parameters
 
@@ -2628,7 +2628,7 @@ Defined in: ridb\_core.d.ts:994
 
 > `readonly` **property\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:995
+Defined in: ridb\_core.d.ts:878
 
 #### Parameters
 
@@ -2650,7 +2650,7 @@ Defined in: ridb\_core.d.ts:995
 
 > `readonly` **property\_type**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:989
+Defined in: ridb\_core.d.ts:872
 
 #### Parameters
 
@@ -2668,7 +2668,7 @@ Defined in: ridb\_core.d.ts:989
 
 > `readonly` **query\_get**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:921
+Defined in: ridb\_core.d.ts:920
 
 #### Parameters
 
@@ -2698,7 +2698,7 @@ Defined in: ridb\_core.d.ts:921
 
 > `readonly` **query\_get\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:918
+Defined in: ridb\_core.d.ts:917
 
 #### Parameters
 
@@ -2720,7 +2720,7 @@ Defined in: ridb\_core.d.ts:918
 
 > `readonly` **query\_has\_or\_operator**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:922
+Defined in: ridb\_core.d.ts:921
 
 #### Parameters
 
@@ -2738,7 +2738,7 @@ Defined in: ridb\_core.d.ts:922
 
 > `readonly` **query\_new**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:916
+Defined in: ridb\_core.d.ts:915
 
 #### Parameters
 
@@ -2764,7 +2764,7 @@ Defined in: ridb\_core.d.ts:916
 
 > `readonly` **query\_parse**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:919
+Defined in: ridb\_core.d.ts:918
 
 #### Parameters
 
@@ -2786,7 +2786,7 @@ Defined in: ridb\_core.d.ts:919
 
 > `readonly` **query\_process\_query**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:920
+Defined in: ridb\_core.d.ts:919
 
 #### Parameters
 
@@ -2812,7 +2812,7 @@ Defined in: ridb\_core.d.ts:920
 
 > `readonly` **query\_query**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:917
+Defined in: ridb\_core.d.ts:916
 
 #### Parameters
 
@@ -2834,7 +2834,7 @@ Defined in: ridb\_core.d.ts:917
 
 > `readonly` **queryoptions\_limit**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:906
+Defined in: ridb\_core.d.ts:975
 
 #### Parameters
 
@@ -2856,7 +2856,7 @@ Defined in: ridb\_core.d.ts:906
 
 > `readonly` **queryoptions\_offset**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:907
+Defined in: ridb\_core.d.ts:976
 
 #### Parameters
 
@@ -2878,7 +2878,7 @@ Defined in: ridb\_core.d.ts:907
 
 > `readonly` **ridberror\_authentication**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:970
+Defined in: ridb\_core.d.ts:992
 
 #### Parameters
 
@@ -2904,7 +2904,7 @@ Defined in: ridb\_core.d.ts:970
 
 > `readonly` **ridberror\_code**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:965
+Defined in: ridb\_core.d.ts:987
 
 #### Parameters
 
@@ -2922,7 +2922,7 @@ Defined in: ridb\_core.d.ts:965
 
 > `readonly` **ridberror\_error**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:968
+Defined in: ridb\_core.d.ts:990
 
 #### Parameters
 
@@ -2948,7 +2948,7 @@ Defined in: ridb\_core.d.ts:968
 
 > `readonly` **ridberror\_from**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:967
+Defined in: ridb\_core.d.ts:989
 
 #### Parameters
 
@@ -2966,7 +2966,7 @@ Defined in: ridb\_core.d.ts:967
 
 > `readonly` **ridberror\_hook**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:973
+Defined in: ridb\_core.d.ts:995
 
 #### Parameters
 
@@ -2992,7 +2992,7 @@ Defined in: ridb\_core.d.ts:973
 
 > `readonly` **ridberror\_message**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:966
+Defined in: ridb\_core.d.ts:988
 
 #### Parameters
 
@@ -3014,7 +3014,7 @@ Defined in: ridb\_core.d.ts:966
 
 > `readonly` **ridberror\_new**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:963
+Defined in: ridb\_core.d.ts:985
 
 #### Parameters
 
@@ -3048,7 +3048,7 @@ Defined in: ridb\_core.d.ts:963
 
 > `readonly` **ridberror\_query**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:969
+Defined in: ridb\_core.d.ts:991
 
 #### Parameters
 
@@ -3074,7 +3074,7 @@ Defined in: ridb\_core.d.ts:969
 
 > `readonly` **ridberror\_serialisation**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:971
+Defined in: ridb\_core.d.ts:993
 
 #### Parameters
 
@@ -3100,7 +3100,7 @@ Defined in: ridb\_core.d.ts:971
 
 > `readonly` **ridberror\_type**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:964
+Defined in: ridb\_core.d.ts:986
 
 #### Parameters
 
@@ -3122,7 +3122,7 @@ Defined in: ridb\_core.d.ts:964
 
 > `readonly` **ridberror\_validation**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:972
+Defined in: ridb\_core.d.ts:994
 
 #### Parameters
 
@@ -3148,7 +3148,7 @@ Defined in: ridb\_core.d.ts:972
 
 > `readonly` **schema\_create**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:977
+Defined in: ridb\_core.d.ts:999
 
 #### Parameters
 
@@ -3170,7 +3170,7 @@ Defined in: ridb\_core.d.ts:977
 
 > `readonly` **schema\_encrypted**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:982
+Defined in: ridb\_core.d.ts:1004
 
 #### Parameters
 
@@ -3192,7 +3192,7 @@ Defined in: ridb\_core.d.ts:982
 
 > `readonly` **schema\_indexes**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:981
+Defined in: ridb\_core.d.ts:1003
 
 #### Parameters
 
@@ -3214,7 +3214,7 @@ Defined in: ridb\_core.d.ts:981
 
 > `readonly` **schema\_is\_valid**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:976
+Defined in: ridb\_core.d.ts:998
 
 #### Parameters
 
@@ -3236,7 +3236,7 @@ Defined in: ridb\_core.d.ts:976
 
 > `readonly` **schema\_primaryKey**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:979
+Defined in: ridb\_core.d.ts:1001
 
 #### Parameters
 
@@ -3258,7 +3258,7 @@ Defined in: ridb\_core.d.ts:979
 
 > `readonly` **schema\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:983
+Defined in: ridb\_core.d.ts:1005
 
 #### Parameters
 
@@ -3280,7 +3280,7 @@ Defined in: ridb\_core.d.ts:983
 
 > `readonly` **schema\_type**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:980
+Defined in: ridb\_core.d.ts:1002
 
 #### Parameters
 
@@ -3302,7 +3302,7 @@ Defined in: ridb\_core.d.ts:980
 
 > `readonly` **schema\_validate**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:975
+Defined in: ridb\_core.d.ts:997
 
 #### Parameters
 
@@ -3328,7 +3328,7 @@ Defined in: ridb\_core.d.ts:975
 
 > `readonly` **schema\_version**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:978
+Defined in: ridb\_core.d.ts:1000
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/interfaces/InitOutput.md
+++ b/docs/@trust0/ridb-core/interfaces/InitOutput.md
@@ -14,7 +14,7 @@ Defined in: ridb\_core.d.ts:868
 
 > `readonly` **\_\_wbg\_baseplugin\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:883
+Defined in: ridb\_core.d.ts:975
 
 #### Parameters
 
@@ -32,7 +32,7 @@ Defined in: ridb\_core.d.ts:883
 
 > `readonly` **\_\_wbg\_basestorage\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:900
+Defined in: ridb\_core.d.ts:880
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: ridb\_core.d.ts:900
 
 > `readonly` **\_\_wbg\_collection\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:890
+Defined in: ridb\_core.d.ts:870
 
 #### Parameters
 
@@ -68,7 +68,7 @@ Defined in: ridb\_core.d.ts:890
 
 > `readonly` **\_\_wbg\_corestorage\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1007
+Defined in: ridb\_core.d.ts:1008
 
 #### Parameters
 
@@ -86,7 +86,7 @@ Defined in: ridb\_core.d.ts:1007
 
 > `readonly` **\_\_wbg\_database\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:992
+Defined in: ridb\_core.d.ts:993
 
 #### Parameters
 
@@ -104,7 +104,7 @@ Defined in: ridb\_core.d.ts:992
 
 > `readonly` **\_\_wbg\_indexdb\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:920
+Defined in: ridb\_core.d.ts:900
 
 #### Parameters
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:920
 
 > `readonly` **\_\_wbg\_inmemory\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:981
+Defined in: ridb\_core.d.ts:982
 
 #### Parameters
 
@@ -140,7 +140,7 @@ Defined in: ridb\_core.d.ts:981
 
 > `readonly` **\_\_wbg\_operation\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:999
+Defined in: ridb\_core.d.ts:1000
 
 #### Parameters
 
@@ -158,7 +158,7 @@ Defined in: ridb\_core.d.ts:999
 
 > `readonly` **\_\_wbg\_property\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:969
+Defined in: ridb\_core.d.ts:950
 
 #### Parameters
 
@@ -176,7 +176,7 @@ Defined in: ridb\_core.d.ts:969
 
 > `readonly` **\_\_wbg\_query\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:933
+Defined in: ridb\_core.d.ts:913
 
 #### Parameters
 
@@ -194,7 +194,7 @@ Defined in: ridb\_core.d.ts:933
 
 > `readonly` **\_\_wbg\_queryoptions\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:930
+Defined in: ridb\_core.d.ts:910
 
 #### Parameters
 
@@ -212,7 +212,7 @@ Defined in: ridb\_core.d.ts:930
 
 > `readonly` **\_\_wbg\_ridberror\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:908
+Defined in: ridb\_core.d.ts:888
 
 #### Parameters
 
@@ -230,7 +230,7 @@ Defined in: ridb\_core.d.ts:908
 
 > `readonly` **\_\_wbg\_schema\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:870
+Defined in: ridb\_core.d.ts:962
 
 #### Parameters
 
@@ -248,7 +248,7 @@ Defined in: ridb\_core.d.ts:870
 
 > `readonly` **\_\_wbg\_wasmbindgentestcontext\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1008
+Defined in: ridb\_core.d.ts:1009
 
 #### Parameters
 
@@ -266,7 +266,7 @@ Defined in: ridb\_core.d.ts:1008
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_array\_values\_10**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:944
+Defined in: ridb\_core.d.ts:925
 
 #### Parameters
 
@@ -284,7 +284,7 @@ Defined in: ridb\_core.d.ts:944
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_deeply\_nested\_12**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:946
+Defined in: ridb\_core.d.ts:927
 
 #### Parameters
 
@@ -302,7 +302,7 @@ Defined in: ridb\_core.d.ts:946
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_empty\_query\_11**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:945
+Defined in: ridb\_core.d.ts:926
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:945
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_nested\_operators\_9**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:943
+Defined in: ridb\_core.d.ts:924
 
 #### Parameters
 
@@ -338,7 +338,7 @@ Defined in: ridb\_core.d.ts:943
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_simple\_fields\_6**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:940
+Defined in: ridb\_core.d.ts:921
 
 #### Parameters
 
@@ -356,7 +356,7 @@ Defined in: ridb\_core.d.ts:940
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_array\_at\_top\_level\_14**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:948
+Defined in: ridb\_core.d.ts:929
 
 #### Parameters
 
@@ -374,7 +374,7 @@ Defined in: ridb\_core.d.ts:948
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_logical\_operators\_8**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:942
+Defined in: ridb\_core.d.ts:923
 
 #### Parameters
 
@@ -392,7 +392,7 @@ Defined in: ridb\_core.d.ts:942
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_multiple\_same\_props\_13**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:947
+Defined in: ridb\_core.d.ts:928
 
 #### Parameters
 
@@ -410,7 +410,7 @@ Defined in: ridb\_core.d.ts:947
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_operators\_7**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:941
+Defined in: ridb\_core.d.ts:922
 
 #### Parameters
 
@@ -428,7 +428,7 @@ Defined in: ridb\_core.d.ts:941
 
 > `readonly` **\_\_wbgt\_test\_invalid\_property\_2**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:980
+Defined in: ridb\_core.d.ts:961
 
 #### Parameters
 
@@ -446,7 +446,7 @@ Defined in: ridb\_core.d.ts:980
 
 > `readonly` **\_\_wbgt\_test\_invalid\_schema\_5**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:882
+Defined in: ridb\_core.d.ts:974
 
 #### Parameters
 
@@ -464,7 +464,7 @@ Defined in: ridb\_core.d.ts:882
 
 > `readonly` **\_\_wbgt\_test\_property\_creation\_0**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:978
+Defined in: ridb\_core.d.ts:959
 
 #### Parameters
 
@@ -482,7 +482,7 @@ Defined in: ridb\_core.d.ts:978
 
 > `readonly` **\_\_wbgt\_test\_property\_validation\_1**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:979
+Defined in: ridb\_core.d.ts:960
 
 #### Parameters
 
@@ -500,7 +500,7 @@ Defined in: ridb\_core.d.ts:979
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_complex\_mixed\_22**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:956
+Defined in: ridb\_core.d.ts:937
 
 #### Parameters
 
@@ -518,7 +518,7 @@ Defined in: ridb\_core.d.ts:956
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_nested\_logical\_operators\_20**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:954
+Defined in: ridb\_core.d.ts:935
 
 #### Parameters
 
@@ -536,7 +536,7 @@ Defined in: ridb\_core.d.ts:954
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_only\_logical\_operator\_21**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:955
+Defined in: ridb\_core.d.ts:936
 
 #### Parameters
 
@@ -554,7 +554,7 @@ Defined in: ridb\_core.d.ts:955
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_simple\_attributes\_18**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:952
+Defined in: ridb\_core.d.ts:933
 
 #### Parameters
 
@@ -572,7 +572,7 @@ Defined in: ridb\_core.d.ts:952
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_with\_logical\_operator\_19**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:953
+Defined in: ridb\_core.d.ts:934
 
 #### Parameters
 
@@ -590,7 +590,7 @@ Defined in: ridb\_core.d.ts:953
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_age\_query\_24**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:958
+Defined in: ridb\_core.d.ts:939
 
 #### Parameters
 
@@ -608,7 +608,7 @@ Defined in: ridb\_core.d.ts:958
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_empty\_logical\_operators\_28**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:962
+Defined in: ridb\_core.d.ts:943
 
 #### Parameters
 
@@ -626,7 +626,7 @@ Defined in: ridb\_core.d.ts:962
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_empty\_query\_23**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:957
+Defined in: ridb\_core.d.ts:938
 
 #### Parameters
 
@@ -644,7 +644,7 @@ Defined in: ridb\_core.d.ts:957
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_eq\_operator\_31**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:965
+Defined in: ridb\_core.d.ts:946
 
 #### Parameters
 
@@ -662,7 +662,7 @@ Defined in: ridb\_core.d.ts:965
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_eq\_operator\_wrong\_type\_32**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:966
+Defined in: ridb\_core.d.ts:947
 
 #### Parameters
 
@@ -680,7 +680,7 @@ Defined in: ridb\_core.d.ts:966
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_in\_operator\_16**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:950
+Defined in: ridb\_core.d.ts:931
 
 #### Parameters
 
@@ -698,7 +698,7 @@ Defined in: ridb\_core.d.ts:950
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_in\_operator\_wrong\_type\_17**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:951
+Defined in: ridb\_core.d.ts:932
 
 #### Parameters
 
@@ -716,7 +716,7 @@ Defined in: ridb\_core.d.ts:951
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_invalid\_in\_operator\_27**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:961
+Defined in: ridb\_core.d.ts:942
 
 #### Parameters
 
@@ -734,7 +734,7 @@ Defined in: ridb\_core.d.ts:961
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_multiple\_operators\_26**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:960
+Defined in: ridb\_core.d.ts:941
 
 #### Parameters
 
@@ -752,7 +752,7 @@ Defined in: ridb\_core.d.ts:960
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_ne\_operator\_33**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:967
+Defined in: ridb\_core.d.ts:948
 
 #### Parameters
 
@@ -770,7 +770,7 @@ Defined in: ridb\_core.d.ts:967
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_ne\_operator\_wrong\_type\_34**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:968
+Defined in: ridb\_core.d.ts:949
 
 #### Parameters
 
@@ -788,7 +788,7 @@ Defined in: ridb\_core.d.ts:968
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_nin\_operator\_29**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:963
+Defined in: ridb\_core.d.ts:944
 
 #### Parameters
 
@@ -806,7 +806,7 @@ Defined in: ridb\_core.d.ts:963
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_nin\_operator\_wrong\_type\_30**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:964
+Defined in: ridb\_core.d.ts:945
 
 #### Parameters
 
@@ -824,7 +824,7 @@ Defined in: ridb\_core.d.ts:964
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_non\_object\_query\_25**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:959
+Defined in: ridb\_core.d.ts:940
 
 #### Parameters
 
@@ -842,7 +842,7 @@ Defined in: ridb\_core.d.ts:959
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_operator\_wrong\_type\_15**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:949
+Defined in: ridb\_core.d.ts:930
 
 #### Parameters
 
@@ -860,7 +860,7 @@ Defined in: ridb\_core.d.ts:949
 
 > `readonly` **\_\_wbgt\_test\_schema\_creation\_3**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:880
+Defined in: ridb\_core.d.ts:972
 
 #### Parameters
 
@@ -878,7 +878,7 @@ Defined in: ridb\_core.d.ts:880
 
 > `readonly` **\_\_wbgt\_test\_schema\_validation\_4**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:881
+Defined in: ridb\_core.d.ts:973
 
 #### Parameters
 
@@ -896,7 +896,7 @@ Defined in: ridb\_core.d.ts:881
 
 > `readonly` **\_\_wbgtest\_console\_debug**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1013
+Defined in: ridb\_core.d.ts:1014
 
 #### Parameters
 
@@ -914,7 +914,7 @@ Defined in: ridb\_core.d.ts:1013
 
 > `readonly` **\_\_wbgtest\_console\_error**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1016
+Defined in: ridb\_core.d.ts:1017
 
 #### Parameters
 
@@ -932,7 +932,7 @@ Defined in: ridb\_core.d.ts:1016
 
 > `readonly` **\_\_wbgtest\_console\_info**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1014
+Defined in: ridb\_core.d.ts:1015
 
 #### Parameters
 
@@ -950,7 +950,7 @@ Defined in: ridb\_core.d.ts:1014
 
 > `readonly` **\_\_wbgtest\_console\_log**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1012
+Defined in: ridb\_core.d.ts:1013
 
 #### Parameters
 
@@ -968,7 +968,7 @@ Defined in: ridb\_core.d.ts:1012
 
 > `readonly` **\_\_wbgtest\_console\_warn**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1015
+Defined in: ridb\_core.d.ts:1016
 
 #### Parameters
 
@@ -986,7 +986,7 @@ Defined in: ridb\_core.d.ts:1015
 
 > `readonly` **\_\_wbindgen\_add\_to\_stack\_pointer**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1021
+Defined in: ridb\_core.d.ts:1022
 
 #### Parameters
 
@@ -1004,7 +1004,7 @@ Defined in: ridb\_core.d.ts:1021
 
 > `readonly` **\_\_wbindgen\_exn\_store**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1025
+Defined in: ridb\_core.d.ts:1026
 
 #### Parameters
 
@@ -1022,7 +1022,7 @@ Defined in: ridb\_core.d.ts:1025
 
 > `readonly` **\_\_wbindgen\_export\_2**: `Table`
 
-Defined in: ridb\_core.d.ts:1019
+Defined in: ridb\_core.d.ts:1020
 
 ***
 
@@ -1030,7 +1030,7 @@ Defined in: ridb\_core.d.ts:1019
 
 > `readonly` **\_\_wbindgen\_free**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:1024
+Defined in: ridb\_core.d.ts:1025
 
 #### Parameters
 
@@ -1056,7 +1056,7 @@ Defined in: ridb\_core.d.ts:1024
 
 > `readonly` **\_\_wbindgen\_malloc**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:1017
+Defined in: ridb\_core.d.ts:1018
 
 #### Parameters
 
@@ -1078,7 +1078,7 @@ Defined in: ridb\_core.d.ts:1017
 
 > `readonly` **\_\_wbindgen\_realloc**: (`a`, `b`, `c`, `d`) => `number`
 
-Defined in: ridb\_core.d.ts:1018
+Defined in: ridb\_core.d.ts:1019
 
 #### Parameters
 
@@ -1108,7 +1108,7 @@ Defined in: ridb\_core.d.ts:1018
 
 > `readonly` **\_\_wbindgen\_start**: () => `void`
 
-Defined in: ridb\_core.d.ts:1029
+Defined in: ridb\_core.d.ts:1030
 
 #### Returns
 
@@ -1120,7 +1120,7 @@ Defined in: ridb\_core.d.ts:1029
 
 > `readonly` **\_dyn\_core\_\_ops\_\_function\_\_Fn\_\_A\_B\_C\_\_\_Output\_\_\_R\_as\_wasm\_bindgen\_\_closure\_\_WasmClosure\_\_\_describe\_\_invoke\_\_he6024291054ff5aa**: (`a`, `b`, `c`, `d`, `e`, `f`) => `void`
 
-Defined in: ridb\_core.d.ts:1022
+Defined in: ridb\_core.d.ts:1023
 
 #### Parameters
 
@@ -1158,7 +1158,7 @@ Defined in: ridb\_core.d.ts:1022
 
 > `readonly` **\_dyn\_core\_\_ops\_\_function\_\_FnMut\_\_A\_\_\_\_Output\_\_\_R\_as\_wasm\_bindgen\_\_closure\_\_WasmClosure\_\_\_describe\_\_invoke\_\_hb6eb1f8e3b5e56e9**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:1023
+Defined in: ridb\_core.d.ts:1024
 
 #### Parameters
 
@@ -1184,7 +1184,7 @@ Defined in: ridb\_core.d.ts:1023
 
 > `readonly` **\_dyn\_core\_\_ops\_\_function\_\_FnMut\_\_A\_\_\_\_Output\_\_\_R\_as\_wasm\_bindgen\_\_closure\_\_WasmClosure\_\_\_describe\_\_invoke\_\_hcf4fe6fd0b7ccc8d**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:1020
+Defined in: ridb\_core.d.ts:1021
 
 #### Parameters
 
@@ -1210,7 +1210,7 @@ Defined in: ridb\_core.d.ts:1020
 
 > `readonly` **baseplugin\_get\_doc\_create\_hook**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:886
+Defined in: ridb\_core.d.ts:978
 
 #### Parameters
 
@@ -1228,7 +1228,7 @@ Defined in: ridb\_core.d.ts:886
 
 > `readonly` **baseplugin\_get\_doc\_recover\_hook**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:887
+Defined in: ridb\_core.d.ts:979
 
 #### Parameters
 
@@ -1246,7 +1246,7 @@ Defined in: ridb\_core.d.ts:887
 
 > `readonly` **baseplugin\_name**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:885
+Defined in: ridb\_core.d.ts:977
 
 #### Parameters
 
@@ -1264,7 +1264,7 @@ Defined in: ridb\_core.d.ts:885
 
 > `readonly` **baseplugin\_new**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:884
+Defined in: ridb\_core.d.ts:976
 
 #### Parameters
 
@@ -1290,7 +1290,7 @@ Defined in: ridb\_core.d.ts:884
 
 > `readonly` **baseplugin\_set\_doc\_create\_hook**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:888
+Defined in: ridb\_core.d.ts:980
 
 #### Parameters
 
@@ -1312,7 +1312,7 @@ Defined in: ridb\_core.d.ts:888
 
 > `readonly` **baseplugin\_set\_doc\_recover\_hook**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:889
+Defined in: ridb\_core.d.ts:981
 
 #### Parameters
 
@@ -1334,7 +1334,7 @@ Defined in: ridb\_core.d.ts:889
 
 > `readonly` **basestorage\_addIndexSchemas**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:902
+Defined in: ridb\_core.d.ts:882
 
 #### Parameters
 
@@ -1356,7 +1356,7 @@ Defined in: ridb\_core.d.ts:902
 
 > `readonly` **basestorage\_core**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:905
+Defined in: ridb\_core.d.ts:885
 
 #### Parameters
 
@@ -1378,7 +1378,7 @@ Defined in: ridb\_core.d.ts:905
 
 > `readonly` **basestorage\_getOption**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:903
+Defined in: ridb\_core.d.ts:883
 
 #### Parameters
 
@@ -1408,7 +1408,7 @@ Defined in: ridb\_core.d.ts:903
 
 > `readonly` **basestorage\_getSchema**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:904
+Defined in: ridb\_core.d.ts:884
 
 #### Parameters
 
@@ -1438,7 +1438,7 @@ Defined in: ridb\_core.d.ts:904
 
 > `readonly` **basestorage\_new**: (`a`, `b`, `c`, `d`, `e`) => `void`
 
-Defined in: ridb\_core.d.ts:901
+Defined in: ridb\_core.d.ts:881
 
 #### Parameters
 
@@ -1472,7 +1472,7 @@ Defined in: ridb\_core.d.ts:901
 
 > `readonly` **collection\_count**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:895
+Defined in: ridb\_core.d.ts:875
 
 #### Parameters
 
@@ -1498,7 +1498,7 @@ Defined in: ridb\_core.d.ts:895
 
 > `readonly` **collection\_create**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:898
+Defined in: ridb\_core.d.ts:878
 
 #### Parameters
 
@@ -1520,7 +1520,7 @@ Defined in: ridb\_core.d.ts:898
 
 > `readonly` **collection\_delete**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:899
+Defined in: ridb\_core.d.ts:879
 
 #### Parameters
 
@@ -1542,7 +1542,7 @@ Defined in: ridb\_core.d.ts:899
 
 > `readonly` **collection\_find**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:893
+Defined in: ridb\_core.d.ts:873
 
 #### Parameters
 
@@ -1568,7 +1568,7 @@ Defined in: ridb\_core.d.ts:893
 
 > `readonly` **collection\_findById**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:896
+Defined in: ridb\_core.d.ts:876
 
 #### Parameters
 
@@ -1590,7 +1590,7 @@ Defined in: ridb\_core.d.ts:896
 
 > `readonly` **collection\_name**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:891
+Defined in: ridb\_core.d.ts:871
 
 #### Parameters
 
@@ -1612,7 +1612,7 @@ Defined in: ridb\_core.d.ts:891
 
 > `readonly` **collection\_parse\_query\_options**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:894
+Defined in: ridb\_core.d.ts:874
 
 #### Parameters
 
@@ -1638,7 +1638,7 @@ Defined in: ridb\_core.d.ts:894
 
 > `readonly` **collection\_schema**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:892
+Defined in: ridb\_core.d.ts:872
 
 #### Parameters
 
@@ -1660,7 +1660,7 @@ Defined in: ridb\_core.d.ts:892
 
 > `readonly` **collection\_update**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:897
+Defined in: ridb\_core.d.ts:877
 
 #### Parameters
 
@@ -1682,7 +1682,7 @@ Defined in: ridb\_core.d.ts:897
 
 > `readonly` **corestorage\_getIndexes**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:990
+Defined in: ridb\_core.d.ts:991
 
 #### Parameters
 
@@ -1712,7 +1712,7 @@ Defined in: ridb\_core.d.ts:990
 
 > `readonly` **corestorage\_getPrimaryKeyTyped**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:989
+Defined in: ridb\_core.d.ts:990
 
 #### Parameters
 
@@ -1738,7 +1738,7 @@ Defined in: ridb\_core.d.ts:989
 
 > `readonly` **corestorage\_matchesQuery**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:991
+Defined in: ridb\_core.d.ts:992
 
 #### Parameters
 
@@ -1768,7 +1768,7 @@ Defined in: ridb\_core.d.ts:991
 
 > `readonly` **corestorage\_new**: () => `number`
 
-Defined in: ridb\_core.d.ts:1006
+Defined in: ridb\_core.d.ts:1007
 
 #### Returns
 
@@ -1780,7 +1780,7 @@ Defined in: ridb\_core.d.ts:1006
 
 > `readonly` **database\_authenticate**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:996
+Defined in: ridb\_core.d.ts:997
 
 #### Parameters
 
@@ -1806,7 +1806,7 @@ Defined in: ridb\_core.d.ts:996
 
 > `readonly` **database\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:994
+Defined in: ridb\_core.d.ts:995
 
 #### Parameters
 
@@ -1824,7 +1824,7 @@ Defined in: ridb\_core.d.ts:994
 
 > `readonly` **database\_collections**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:997
+Defined in: ridb\_core.d.ts:998
 
 #### Parameters
 
@@ -1846,7 +1846,7 @@ Defined in: ridb\_core.d.ts:997
 
 > `readonly` **database\_create**: (`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`) => `number`
 
-Defined in: ridb\_core.d.ts:998
+Defined in: ridb\_core.d.ts:999
 
 #### Parameters
 
@@ -1896,7 +1896,7 @@ Defined in: ridb\_core.d.ts:998
 
 > `readonly` **database\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:993
+Defined in: ridb\_core.d.ts:994
 
 #### Parameters
 
@@ -1914,7 +1914,7 @@ Defined in: ridb\_core.d.ts:993
 
 > `readonly` **database\_started**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:995
+Defined in: ridb\_core.d.ts:996
 
 #### Parameters
 
@@ -1932,7 +1932,7 @@ Defined in: ridb\_core.d.ts:995
 
 > `readonly` **indexdb\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:928
+Defined in: ridb\_core.d.ts:908
 
 #### Parameters
 
@@ -1950,7 +1950,7 @@ Defined in: ridb\_core.d.ts:928
 
 > `readonly` **indexdb\_count**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:927
+Defined in: ridb\_core.d.ts:907
 
 #### Parameters
 
@@ -1984,7 +1984,7 @@ Defined in: ridb\_core.d.ts:927
 
 > `readonly` **indexdb\_create**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:923
+Defined in: ridb\_core.d.ts:903
 
 #### Parameters
 
@@ -2010,7 +2010,7 @@ Defined in: ridb\_core.d.ts:923
 
 > `readonly` **indexdb\_find**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:925
+Defined in: ridb\_core.d.ts:905
 
 #### Parameters
 
@@ -2044,7 +2044,7 @@ Defined in: ridb\_core.d.ts:925
 
 > `readonly` **indexdb\_findDocumentById**: (`a`, `b`, `c`, `d`) => `number`
 
-Defined in: ridb\_core.d.ts:926
+Defined in: ridb\_core.d.ts:906
 
 #### Parameters
 
@@ -2074,7 +2074,7 @@ Defined in: ridb\_core.d.ts:926
 
 > `readonly` **indexdb\_get\_store**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:922
+Defined in: ridb\_core.d.ts:902
 
 #### Parameters
 
@@ -2104,7 +2104,7 @@ Defined in: ridb\_core.d.ts:922
 
 > `readonly` **indexdb\_get\_stores**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:921
+Defined in: ridb\_core.d.ts:901
 
 #### Parameters
 
@@ -2126,7 +2126,7 @@ Defined in: ridb\_core.d.ts:921
 
 > `readonly` **indexdb\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:929
+Defined in: ridb\_core.d.ts:909
 
 #### Parameters
 
@@ -2144,7 +2144,7 @@ Defined in: ridb\_core.d.ts:929
 
 > `readonly` **indexdb\_write**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:924
+Defined in: ridb\_core.d.ts:904
 
 #### Parameters
 
@@ -2166,7 +2166,7 @@ Defined in: ridb\_core.d.ts:924
 
 > `readonly` **inmemory\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:987
+Defined in: ridb\_core.d.ts:988
 
 #### Parameters
 
@@ -2184,7 +2184,7 @@ Defined in: ridb\_core.d.ts:987
 
 > `readonly` **inmemory\_count**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:986
+Defined in: ridb\_core.d.ts:987
 
 #### Parameters
 
@@ -2218,7 +2218,7 @@ Defined in: ridb\_core.d.ts:986
 
 > `readonly` **inmemory\_create**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:982
+Defined in: ridb\_core.d.ts:983
 
 #### Parameters
 
@@ -2244,7 +2244,7 @@ Defined in: ridb\_core.d.ts:982
 
 > `readonly` **inmemory\_find**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:984
+Defined in: ridb\_core.d.ts:985
 
 #### Parameters
 
@@ -2278,7 +2278,7 @@ Defined in: ridb\_core.d.ts:984
 
 > `readonly` **inmemory\_findDocumentById**: (`a`, `b`, `c`, `d`) => `number`
 
-Defined in: ridb\_core.d.ts:985
+Defined in: ridb\_core.d.ts:986
 
 #### Parameters
 
@@ -2308,7 +2308,7 @@ Defined in: ridb\_core.d.ts:985
 
 > `readonly` **inmemory\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:988
+Defined in: ridb\_core.d.ts:989
 
 #### Parameters
 
@@ -2326,7 +2326,7 @@ Defined in: ridb\_core.d.ts:988
 
 > `readonly` **inmemory\_write**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:983
+Defined in: ridb\_core.d.ts:984
 
 #### Parameters
 
@@ -2348,7 +2348,7 @@ Defined in: ridb\_core.d.ts:983
 
 > `readonly` **is\_debug\_mode**: () => `number`
 
-Defined in: ridb\_core.d.ts:907
+Defined in: ridb\_core.d.ts:887
 
 #### Returns
 
@@ -2360,7 +2360,7 @@ Defined in: ridb\_core.d.ts:907
 
 > `readonly` **main\_js**: () => `void`
 
-Defined in: ridb\_core.d.ts:906
+Defined in: ridb\_core.d.ts:886
 
 #### Returns
 
@@ -2380,7 +2380,7 @@ Defined in: ridb\_core.d.ts:869
 
 > `readonly` **operation\_collection**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1000
+Defined in: ridb\_core.d.ts:1001
 
 #### Parameters
 
@@ -2402,7 +2402,7 @@ Defined in: ridb\_core.d.ts:1000
 
 > `readonly` **operation\_data**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1002
+Defined in: ridb\_core.d.ts:1003
 
 #### Parameters
 
@@ -2420,7 +2420,7 @@ Defined in: ridb\_core.d.ts:1002
 
 > `readonly` **operation\_opType**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1001
+Defined in: ridb\_core.d.ts:1002
 
 #### Parameters
 
@@ -2438,7 +2438,7 @@ Defined in: ridb\_core.d.ts:1001
 
 > `readonly` **operation\_primaryKey**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1004
+Defined in: ridb\_core.d.ts:1005
 
 #### Parameters
 
@@ -2456,7 +2456,7 @@ Defined in: ridb\_core.d.ts:1004
 
 > `readonly` **operation\_primaryKeyField**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1003
+Defined in: ridb\_core.d.ts:1004
 
 #### Parameters
 
@@ -2474,7 +2474,7 @@ Defined in: ridb\_core.d.ts:1003
 
 > `readonly` **operation\_primaryKeyIndex**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1005
+Defined in: ridb\_core.d.ts:1006
 
 #### Parameters
 
@@ -2496,7 +2496,7 @@ Defined in: ridb\_core.d.ts:1005
 
 > `readonly` **property\_is\_valid**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:970
+Defined in: ridb\_core.d.ts:951
 
 #### Parameters
 
@@ -2518,7 +2518,7 @@ Defined in: ridb\_core.d.ts:970
 
 > `readonly` **property\_items**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:972
+Defined in: ridb\_core.d.ts:953
 
 #### Parameters
 
@@ -2540,7 +2540,7 @@ Defined in: ridb\_core.d.ts:972
 
 > `readonly` **property\_maxItems**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:973
+Defined in: ridb\_core.d.ts:954
 
 #### Parameters
 
@@ -2562,7 +2562,7 @@ Defined in: ridb\_core.d.ts:973
 
 > `readonly` **property\_maxLength**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:975
+Defined in: ridb\_core.d.ts:956
 
 #### Parameters
 
@@ -2584,7 +2584,7 @@ Defined in: ridb\_core.d.ts:975
 
 > `readonly` **property\_minItems**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:974
+Defined in: ridb\_core.d.ts:955
 
 #### Parameters
 
@@ -2606,7 +2606,7 @@ Defined in: ridb\_core.d.ts:974
 
 > `readonly` **property\_minLength**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:976
+Defined in: ridb\_core.d.ts:957
 
 #### Parameters
 
@@ -2628,7 +2628,7 @@ Defined in: ridb\_core.d.ts:976
 
 > `readonly` **property\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:977
+Defined in: ridb\_core.d.ts:958
 
 #### Parameters
 
@@ -2650,7 +2650,7 @@ Defined in: ridb\_core.d.ts:977
 
 > `readonly` **property\_type**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:971
+Defined in: ridb\_core.d.ts:952
 
 #### Parameters
 
@@ -2668,7 +2668,7 @@ Defined in: ridb\_core.d.ts:971
 
 > `readonly` **query\_get**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:939
+Defined in: ridb\_core.d.ts:919
 
 #### Parameters
 
@@ -2698,7 +2698,7 @@ Defined in: ridb\_core.d.ts:939
 
 > `readonly` **query\_get\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:936
+Defined in: ridb\_core.d.ts:916
 
 #### Parameters
 
@@ -2716,11 +2716,29 @@ Defined in: ridb\_core.d.ts:936
 
 ***
 
+### query\_has\_or\_operator()
+
+> `readonly` **query\_has\_or\_operator**: (`a`) => `number`
+
+Defined in: ridb\_core.d.ts:920
+
+#### Parameters
+
+##### a
+
+`number`
+
+#### Returns
+
+`number`
+
+***
+
 ### query\_new()
 
 > `readonly` **query\_new**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:934
+Defined in: ridb\_core.d.ts:914
 
 #### Parameters
 
@@ -2746,7 +2764,7 @@ Defined in: ridb\_core.d.ts:934
 
 > `readonly` **query\_parse**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:937
+Defined in: ridb\_core.d.ts:917
 
 #### Parameters
 
@@ -2768,7 +2786,7 @@ Defined in: ridb\_core.d.ts:937
 
 > `readonly` **query\_process\_query**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:938
+Defined in: ridb\_core.d.ts:918
 
 #### Parameters
 
@@ -2794,7 +2812,7 @@ Defined in: ridb\_core.d.ts:938
 
 > `readonly` **query\_query**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:935
+Defined in: ridb\_core.d.ts:915
 
 #### Parameters
 
@@ -2816,7 +2834,7 @@ Defined in: ridb\_core.d.ts:935
 
 > `readonly` **queryoptions\_limit**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:931
+Defined in: ridb\_core.d.ts:911
 
 #### Parameters
 
@@ -2838,7 +2856,7 @@ Defined in: ridb\_core.d.ts:931
 
 > `readonly` **queryoptions\_offset**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:932
+Defined in: ridb\_core.d.ts:912
 
 #### Parameters
 
@@ -2860,7 +2878,7 @@ Defined in: ridb\_core.d.ts:932
 
 > `readonly` **ridberror\_authentication**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:916
+Defined in: ridb\_core.d.ts:896
 
 #### Parameters
 
@@ -2886,7 +2904,7 @@ Defined in: ridb\_core.d.ts:916
 
 > `readonly` **ridberror\_code**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:911
+Defined in: ridb\_core.d.ts:891
 
 #### Parameters
 
@@ -2904,7 +2922,7 @@ Defined in: ridb\_core.d.ts:911
 
 > `readonly` **ridberror\_error**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:914
+Defined in: ridb\_core.d.ts:894
 
 #### Parameters
 
@@ -2930,7 +2948,7 @@ Defined in: ridb\_core.d.ts:914
 
 > `readonly` **ridberror\_from**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:913
+Defined in: ridb\_core.d.ts:893
 
 #### Parameters
 
@@ -2948,7 +2966,7 @@ Defined in: ridb\_core.d.ts:913
 
 > `readonly` **ridberror\_hook**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:919
+Defined in: ridb\_core.d.ts:899
 
 #### Parameters
 
@@ -2974,7 +2992,7 @@ Defined in: ridb\_core.d.ts:919
 
 > `readonly` **ridberror\_message**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:912
+Defined in: ridb\_core.d.ts:892
 
 #### Parameters
 
@@ -2996,7 +3014,7 @@ Defined in: ridb\_core.d.ts:912
 
 > `readonly` **ridberror\_new**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:909
+Defined in: ridb\_core.d.ts:889
 
 #### Parameters
 
@@ -3030,7 +3048,7 @@ Defined in: ridb\_core.d.ts:909
 
 > `readonly` **ridberror\_query**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:915
+Defined in: ridb\_core.d.ts:895
 
 #### Parameters
 
@@ -3056,7 +3074,7 @@ Defined in: ridb\_core.d.ts:915
 
 > `readonly` **ridberror\_serialisation**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:917
+Defined in: ridb\_core.d.ts:897
 
 #### Parameters
 
@@ -3082,7 +3100,7 @@ Defined in: ridb\_core.d.ts:917
 
 > `readonly` **ridberror\_type**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:910
+Defined in: ridb\_core.d.ts:890
 
 #### Parameters
 
@@ -3104,7 +3122,7 @@ Defined in: ridb\_core.d.ts:910
 
 > `readonly` **ridberror\_validation**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:918
+Defined in: ridb\_core.d.ts:898
 
 #### Parameters
 
@@ -3130,7 +3148,7 @@ Defined in: ridb\_core.d.ts:918
 
 > `readonly` **schema\_create**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:873
+Defined in: ridb\_core.d.ts:965
 
 #### Parameters
 
@@ -3152,7 +3170,7 @@ Defined in: ridb\_core.d.ts:873
 
 > `readonly` **schema\_encrypted**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:878
+Defined in: ridb\_core.d.ts:970
 
 #### Parameters
 
@@ -3174,7 +3192,7 @@ Defined in: ridb\_core.d.ts:878
 
 > `readonly` **schema\_indexes**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:877
+Defined in: ridb\_core.d.ts:969
 
 #### Parameters
 
@@ -3196,7 +3214,7 @@ Defined in: ridb\_core.d.ts:877
 
 > `readonly` **schema\_is\_valid**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:872
+Defined in: ridb\_core.d.ts:964
 
 #### Parameters
 
@@ -3218,7 +3236,7 @@ Defined in: ridb\_core.d.ts:872
 
 > `readonly` **schema\_primaryKey**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:875
+Defined in: ridb\_core.d.ts:967
 
 #### Parameters
 
@@ -3240,7 +3258,7 @@ Defined in: ridb\_core.d.ts:875
 
 > `readonly` **schema\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:879
+Defined in: ridb\_core.d.ts:971
 
 #### Parameters
 
@@ -3262,7 +3280,7 @@ Defined in: ridb\_core.d.ts:879
 
 > `readonly` **schema\_type**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:876
+Defined in: ridb\_core.d.ts:968
 
 #### Parameters
 
@@ -3284,7 +3302,7 @@ Defined in: ridb\_core.d.ts:876
 
 > `readonly` **schema\_validate**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:871
+Defined in: ridb\_core.d.ts:963
 
 #### Parameters
 
@@ -3310,7 +3328,7 @@ Defined in: ridb\_core.d.ts:871
 
 > `readonly` **schema\_version**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:874
+Defined in: ridb\_core.d.ts:966
 
 #### Parameters
 
@@ -3328,7 +3346,7 @@ Defined in: ridb\_core.d.ts:874
 
 > `readonly` **wasm\_bindgen\_\_convert\_\_closures\_\_invoke0\_mut\_\_hff00333f3d941090**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1026
+Defined in: ridb\_core.d.ts:1027
 
 #### Parameters
 
@@ -3350,7 +3368,7 @@ Defined in: ridb\_core.d.ts:1026
 
 > `readonly` **wasm\_bindgen\_\_convert\_\_closures\_\_invoke2\_mut\_\_h97988f5fa0547d24**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:1028
+Defined in: ridb\_core.d.ts:1029
 
 #### Parameters
 
@@ -3380,7 +3398,7 @@ Defined in: ridb\_core.d.ts:1028
 
 > `readonly` **wasm\_bindgen\_\_convert\_\_closures\_\_invoke3\_mut\_\_h703f9c33fd3008bf**: (`a`, `b`, `c`, `d`, `e`) => `void`
 
-Defined in: ridb\_core.d.ts:1027
+Defined in: ridb\_core.d.ts:1028
 
 #### Parameters
 
@@ -3414,7 +3432,7 @@ Defined in: ridb\_core.d.ts:1027
 
 > `readonly` **wasmbindgentestcontext\_args**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:1010
+Defined in: ridb\_core.d.ts:1011
 
 #### Parameters
 
@@ -3440,7 +3458,7 @@ Defined in: ridb\_core.d.ts:1010
 
 > `readonly` **wasmbindgentestcontext\_new**: () => `number`
 
-Defined in: ridb\_core.d.ts:1009
+Defined in: ridb\_core.d.ts:1010
 
 #### Returns
 
@@ -3452,7 +3470,7 @@ Defined in: ridb\_core.d.ts:1009
 
 > `readonly` **wasmbindgentestcontext\_run**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:1011
+Defined in: ridb\_core.d.ts:1012
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/interfaces/InitOutput.md
+++ b/docs/@trust0/ridb-core/interfaces/InitOutput.md
@@ -14,7 +14,7 @@ Defined in: ridb\_core.d.ts:868
 
 > `readonly` **\_\_wbg\_baseplugin\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:977
+Defined in: ridb\_core.d.ts:918
 
 #### Parameters
 
@@ -32,7 +32,7 @@ Defined in: ridb\_core.d.ts:977
 
 > `readonly` **\_\_wbg\_basestorage\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:961
+Defined in: ridb\_core.d.ts:905
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: ridb\_core.d.ts:961
 
 > `readonly` **\_\_wbg\_collection\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:892
+Defined in: ridb\_core.d.ts:944
 
 #### Parameters
 
@@ -68,7 +68,7 @@ Defined in: ridb\_core.d.ts:892
 
 > `readonly` **\_\_wbg\_corestorage\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:913
+Defined in: ridb\_core.d.ts:943
 
 #### Parameters
 
@@ -86,7 +86,7 @@ Defined in: ridb\_core.d.ts:913
 
 > `readonly` **\_\_wbg\_database\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:967
+Defined in: ridb\_core.d.ts:911
 
 #### Parameters
 
@@ -104,7 +104,7 @@ Defined in: ridb\_core.d.ts:967
 
 > `readonly` **\_\_wbg\_indexdb\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:882
+Defined in: ridb\_core.d.ts:925
 
 #### Parameters
 
@@ -122,7 +122,7 @@ Defined in: ridb\_core.d.ts:882
 
 > `readonly` **\_\_wbg\_inmemory\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:951
+Defined in: ridb\_core.d.ts:897
 
 #### Parameters
 
@@ -140,7 +140,7 @@ Defined in: ridb\_core.d.ts:951
 
 > `readonly` **\_\_wbg\_operation\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:905
+Defined in: ridb\_core.d.ts:1003
 
 #### Parameters
 
@@ -158,7 +158,7 @@ Defined in: ridb\_core.d.ts:905
 
 > `readonly` **\_\_wbg\_property\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:870
+Defined in: ridb\_core.d.ts:991
 
 #### Parameters
 
@@ -176,7 +176,7 @@ Defined in: ridb\_core.d.ts:870
 
 > `readonly` **\_\_wbg\_query\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:914
+Defined in: ridb\_core.d.ts:954
 
 #### Parameters
 
@@ -194,7 +194,7 @@ Defined in: ridb\_core.d.ts:914
 
 > `readonly` **\_\_wbg\_queryoptions\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:974
+Defined in: ridb\_core.d.ts:939
 
 #### Parameters
 
@@ -212,7 +212,7 @@ Defined in: ridb\_core.d.ts:974
 
 > `readonly` **\_\_wbg\_ridberror\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:984
+Defined in: ridb\_core.d.ts:870
 
 #### Parameters
 
@@ -230,7 +230,7 @@ Defined in: ridb\_core.d.ts:984
 
 > `readonly` **\_\_wbg\_schema\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:996
+Defined in: ridb\_core.d.ts:882
 
 #### Parameters
 
@@ -248,7 +248,7 @@ Defined in: ridb\_core.d.ts:996
 
 > `readonly` **\_\_wbg\_wasmbindgentestcontext\_free**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1009
+Defined in: ridb\_core.d.ts:1010
 
 #### Parameters
 
@@ -266,7 +266,7 @@ Defined in: ridb\_core.d.ts:1009
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_array\_values\_10**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:926
+Defined in: ridb\_core.d.ts:966
 
 #### Parameters
 
@@ -284,7 +284,7 @@ Defined in: ridb\_core.d.ts:926
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_deeply\_nested\_12**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:928
+Defined in: ridb\_core.d.ts:968
 
 #### Parameters
 
@@ -302,7 +302,7 @@ Defined in: ridb\_core.d.ts:928
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_empty\_query\_11**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:927
+Defined in: ridb\_core.d.ts:967
 
 #### Parameters
 
@@ -320,7 +320,7 @@ Defined in: ridb\_core.d.ts:927
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_nested\_operators\_9**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:925
+Defined in: ridb\_core.d.ts:965
 
 #### Parameters
 
@@ -338,7 +338,7 @@ Defined in: ridb\_core.d.ts:925
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_simple\_fields\_6**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:922
+Defined in: ridb\_core.d.ts:962
 
 #### Parameters
 
@@ -356,7 +356,7 @@ Defined in: ridb\_core.d.ts:922
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_array\_at\_top\_level\_14**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:930
+Defined in: ridb\_core.d.ts:970
 
 #### Parameters
 
@@ -374,7 +374,7 @@ Defined in: ridb\_core.d.ts:930
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_logical\_operators\_8**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:924
+Defined in: ridb\_core.d.ts:964
 
 #### Parameters
 
@@ -392,7 +392,7 @@ Defined in: ridb\_core.d.ts:924
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_multiple\_same\_props\_13**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:929
+Defined in: ridb\_core.d.ts:969
 
 #### Parameters
 
@@ -410,7 +410,7 @@ Defined in: ridb\_core.d.ts:929
 
 > `readonly` **\_\_wbgt\_test\_get\_properties\_with\_operators\_7**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:923
+Defined in: ridb\_core.d.ts:963
 
 #### Parameters
 
@@ -428,7 +428,7 @@ Defined in: ridb\_core.d.ts:923
 
 > `readonly` **\_\_wbgt\_test\_invalid\_property\_2**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:881
+Defined in: ridb\_core.d.ts:1002
 
 #### Parameters
 
@@ -446,7 +446,7 @@ Defined in: ridb\_core.d.ts:881
 
 > `readonly` **\_\_wbgt\_test\_invalid\_schema\_5**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1008
+Defined in: ridb\_core.d.ts:894
 
 #### Parameters
 
@@ -464,7 +464,7 @@ Defined in: ridb\_core.d.ts:1008
 
 > `readonly` **\_\_wbgt\_test\_property\_creation\_0**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:879
+Defined in: ridb\_core.d.ts:1000
 
 #### Parameters
 
@@ -482,7 +482,7 @@ Defined in: ridb\_core.d.ts:879
 
 > `readonly` **\_\_wbgt\_test\_property\_validation\_1**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:880
+Defined in: ridb\_core.d.ts:1001
 
 #### Parameters
 
@@ -500,7 +500,7 @@ Defined in: ridb\_core.d.ts:880
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_complex\_mixed\_22**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:938
+Defined in: ridb\_core.d.ts:978
 
 #### Parameters
 
@@ -518,7 +518,7 @@ Defined in: ridb\_core.d.ts:938
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_nested\_logical\_operators\_20**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:936
+Defined in: ridb\_core.d.ts:976
 
 #### Parameters
 
@@ -536,7 +536,7 @@ Defined in: ridb\_core.d.ts:936
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_only\_logical\_operator\_21**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:937
+Defined in: ridb\_core.d.ts:977
 
 #### Parameters
 
@@ -554,7 +554,7 @@ Defined in: ridb\_core.d.ts:937
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_simple\_attributes\_18**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:934
+Defined in: ridb\_core.d.ts:974
 
 #### Parameters
 
@@ -572,7 +572,7 @@ Defined in: ridb\_core.d.ts:934
 
 > `readonly` **\_\_wbgt\_test\_query\_get\_query\_normalization\_with\_logical\_operator\_19**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:935
+Defined in: ridb\_core.d.ts:975
 
 #### Parameters
 
@@ -590,7 +590,7 @@ Defined in: ridb\_core.d.ts:935
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_age\_query\_24**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:940
+Defined in: ridb\_core.d.ts:980
 
 #### Parameters
 
@@ -608,7 +608,7 @@ Defined in: ridb\_core.d.ts:940
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_empty\_logical\_operators\_28**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:944
+Defined in: ridb\_core.d.ts:984
 
 #### Parameters
 
@@ -626,7 +626,7 @@ Defined in: ridb\_core.d.ts:944
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_empty\_query\_23**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:939
+Defined in: ridb\_core.d.ts:979
 
 #### Parameters
 
@@ -644,7 +644,7 @@ Defined in: ridb\_core.d.ts:939
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_eq\_operator\_31**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:947
+Defined in: ridb\_core.d.ts:987
 
 #### Parameters
 
@@ -662,7 +662,7 @@ Defined in: ridb\_core.d.ts:947
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_eq\_operator\_wrong\_type\_32**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:948
+Defined in: ridb\_core.d.ts:988
 
 #### Parameters
 
@@ -680,7 +680,7 @@ Defined in: ridb\_core.d.ts:948
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_in\_operator\_16**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:932
+Defined in: ridb\_core.d.ts:972
 
 #### Parameters
 
@@ -698,7 +698,7 @@ Defined in: ridb\_core.d.ts:932
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_in\_operator\_wrong\_type\_17**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:933
+Defined in: ridb\_core.d.ts:973
 
 #### Parameters
 
@@ -716,7 +716,7 @@ Defined in: ridb\_core.d.ts:933
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_invalid\_in\_operator\_27**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:943
+Defined in: ridb\_core.d.ts:983
 
 #### Parameters
 
@@ -734,7 +734,7 @@ Defined in: ridb\_core.d.ts:943
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_multiple\_operators\_26**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:942
+Defined in: ridb\_core.d.ts:982
 
 #### Parameters
 
@@ -752,7 +752,7 @@ Defined in: ridb\_core.d.ts:942
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_ne\_operator\_33**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:949
+Defined in: ridb\_core.d.ts:989
 
 #### Parameters
 
@@ -770,7 +770,7 @@ Defined in: ridb\_core.d.ts:949
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_ne\_operator\_wrong\_type\_34**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:950
+Defined in: ridb\_core.d.ts:990
 
 #### Parameters
 
@@ -788,7 +788,7 @@ Defined in: ridb\_core.d.ts:950
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_nin\_operator\_29**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:945
+Defined in: ridb\_core.d.ts:985
 
 #### Parameters
 
@@ -806,7 +806,7 @@ Defined in: ridb\_core.d.ts:945
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_nin\_operator\_wrong\_type\_30**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:946
+Defined in: ridb\_core.d.ts:986
 
 #### Parameters
 
@@ -824,7 +824,7 @@ Defined in: ridb\_core.d.ts:946
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_non\_object\_query\_25**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:941
+Defined in: ridb\_core.d.ts:981
 
 #### Parameters
 
@@ -842,7 +842,7 @@ Defined in: ridb\_core.d.ts:941
 
 > `readonly` **\_\_wbgt\_test\_query\_parse\_operator\_wrong\_type\_15**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:931
+Defined in: ridb\_core.d.ts:971
 
 #### Parameters
 
@@ -860,7 +860,7 @@ Defined in: ridb\_core.d.ts:931
 
 > `readonly` **\_\_wbgt\_test\_schema\_creation\_3**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1006
+Defined in: ridb\_core.d.ts:892
 
 #### Parameters
 
@@ -878,7 +878,7 @@ Defined in: ridb\_core.d.ts:1006
 
 > `readonly` **\_\_wbgt\_test\_schema\_validation\_4**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1007
+Defined in: ridb\_core.d.ts:893
 
 #### Parameters
 
@@ -896,7 +896,7 @@ Defined in: ridb\_core.d.ts:1007
 
 > `readonly` **\_\_wbgtest\_console\_debug**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1014
+Defined in: ridb\_core.d.ts:1015
 
 #### Parameters
 
@@ -914,7 +914,7 @@ Defined in: ridb\_core.d.ts:1014
 
 > `readonly` **\_\_wbgtest\_console\_error**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1017
+Defined in: ridb\_core.d.ts:1018
 
 #### Parameters
 
@@ -932,7 +932,7 @@ Defined in: ridb\_core.d.ts:1017
 
 > `readonly` **\_\_wbgtest\_console\_info**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1015
+Defined in: ridb\_core.d.ts:1016
 
 #### Parameters
 
@@ -950,7 +950,7 @@ Defined in: ridb\_core.d.ts:1015
 
 > `readonly` **\_\_wbgtest\_console\_log**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1013
+Defined in: ridb\_core.d.ts:1014
 
 #### Parameters
 
@@ -968,7 +968,7 @@ Defined in: ridb\_core.d.ts:1013
 
 > `readonly` **\_\_wbgtest\_console\_warn**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1016
+Defined in: ridb\_core.d.ts:1017
 
 #### Parameters
 
@@ -986,7 +986,7 @@ Defined in: ridb\_core.d.ts:1016
 
 > `readonly` **\_\_wbindgen\_add\_to\_stack\_pointer**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1022
+Defined in: ridb\_core.d.ts:1023
 
 #### Parameters
 
@@ -1004,7 +1004,7 @@ Defined in: ridb\_core.d.ts:1022
 
 > `readonly` **\_\_wbindgen\_exn\_store**: (`a`) => `void`
 
-Defined in: ridb\_core.d.ts:1026
+Defined in: ridb\_core.d.ts:1027
 
 #### Parameters
 
@@ -1022,7 +1022,7 @@ Defined in: ridb\_core.d.ts:1026
 
 > `readonly` **\_\_wbindgen\_export\_2**: `Table`
 
-Defined in: ridb\_core.d.ts:1020
+Defined in: ridb\_core.d.ts:1021
 
 ***
 
@@ -1030,7 +1030,7 @@ Defined in: ridb\_core.d.ts:1020
 
 > `readonly` **\_\_wbindgen\_free**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:1025
+Defined in: ridb\_core.d.ts:1026
 
 #### Parameters
 
@@ -1056,7 +1056,7 @@ Defined in: ridb\_core.d.ts:1025
 
 > `readonly` **\_\_wbindgen\_malloc**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:1018
+Defined in: ridb\_core.d.ts:1019
 
 #### Parameters
 
@@ -1078,7 +1078,7 @@ Defined in: ridb\_core.d.ts:1018
 
 > `readonly` **\_\_wbindgen\_realloc**: (`a`, `b`, `c`, `d`) => `number`
 
-Defined in: ridb\_core.d.ts:1019
+Defined in: ridb\_core.d.ts:1020
 
 #### Parameters
 
@@ -1108,7 +1108,7 @@ Defined in: ridb\_core.d.ts:1019
 
 > `readonly` **\_\_wbindgen\_start**: () => `void`
 
-Defined in: ridb\_core.d.ts:1030
+Defined in: ridb\_core.d.ts:1031
 
 #### Returns
 
@@ -1120,7 +1120,7 @@ Defined in: ridb\_core.d.ts:1030
 
 > `readonly` **\_dyn\_core\_\_ops\_\_function\_\_Fn\_\_A\_B\_C\_\_\_Output\_\_\_R\_as\_wasm\_bindgen\_\_closure\_\_WasmClosure\_\_\_describe\_\_invoke\_\_he6024291054ff5aa**: (`a`, `b`, `c`, `d`, `e`, `f`) => `void`
 
-Defined in: ridb\_core.d.ts:1023
+Defined in: ridb\_core.d.ts:1024
 
 #### Parameters
 
@@ -1158,7 +1158,7 @@ Defined in: ridb\_core.d.ts:1023
 
 > `readonly` **\_dyn\_core\_\_ops\_\_function\_\_FnMut\_\_A\_\_\_\_Output\_\_\_R\_as\_wasm\_bindgen\_\_closure\_\_WasmClosure\_\_\_describe\_\_invoke\_\_hb6eb1f8e3b5e56e9**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:1024
+Defined in: ridb\_core.d.ts:1025
 
 #### Parameters
 
@@ -1184,7 +1184,7 @@ Defined in: ridb\_core.d.ts:1024
 
 > `readonly` **\_dyn\_core\_\_ops\_\_function\_\_FnMut\_\_A\_\_\_\_Output\_\_\_R\_as\_wasm\_bindgen\_\_closure\_\_WasmClosure\_\_\_describe\_\_invoke\_\_hcf4fe6fd0b7ccc8d**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:1021
+Defined in: ridb\_core.d.ts:1022
 
 #### Parameters
 
@@ -1210,7 +1210,7 @@ Defined in: ridb\_core.d.ts:1021
 
 > `readonly` **baseplugin\_get\_doc\_create\_hook**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:980
+Defined in: ridb\_core.d.ts:921
 
 #### Parameters
 
@@ -1228,7 +1228,7 @@ Defined in: ridb\_core.d.ts:980
 
 > `readonly` **baseplugin\_get\_doc\_recover\_hook**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:981
+Defined in: ridb\_core.d.ts:922
 
 #### Parameters
 
@@ -1246,7 +1246,7 @@ Defined in: ridb\_core.d.ts:981
 
 > `readonly` **baseplugin\_name**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:979
+Defined in: ridb\_core.d.ts:920
 
 #### Parameters
 
@@ -1264,7 +1264,7 @@ Defined in: ridb\_core.d.ts:979
 
 > `readonly` **baseplugin\_new**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:978
+Defined in: ridb\_core.d.ts:919
 
 #### Parameters
 
@@ -1290,7 +1290,7 @@ Defined in: ridb\_core.d.ts:978
 
 > `readonly` **baseplugin\_set\_doc\_create\_hook**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:982
+Defined in: ridb\_core.d.ts:923
 
 #### Parameters
 
@@ -1312,7 +1312,7 @@ Defined in: ridb\_core.d.ts:982
 
 > `readonly` **baseplugin\_set\_doc\_recover\_hook**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:983
+Defined in: ridb\_core.d.ts:924
 
 #### Parameters
 
@@ -1334,7 +1334,7 @@ Defined in: ridb\_core.d.ts:983
 
 > `readonly` **basestorage\_addIndexSchemas**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:963
+Defined in: ridb\_core.d.ts:907
 
 #### Parameters
 
@@ -1356,7 +1356,7 @@ Defined in: ridb\_core.d.ts:963
 
 > `readonly` **basestorage\_core**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:966
+Defined in: ridb\_core.d.ts:910
 
 #### Parameters
 
@@ -1378,7 +1378,7 @@ Defined in: ridb\_core.d.ts:966
 
 > `readonly` **basestorage\_getOption**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:964
+Defined in: ridb\_core.d.ts:908
 
 #### Parameters
 
@@ -1408,7 +1408,7 @@ Defined in: ridb\_core.d.ts:964
 
 > `readonly` **basestorage\_getSchema**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:965
+Defined in: ridb\_core.d.ts:909
 
 #### Parameters
 
@@ -1438,7 +1438,7 @@ Defined in: ridb\_core.d.ts:965
 
 > `readonly` **basestorage\_new**: (`a`, `b`, `c`, `d`, `e`) => `void`
 
-Defined in: ridb\_core.d.ts:962
+Defined in: ridb\_core.d.ts:906
 
 #### Parameters
 
@@ -1472,7 +1472,7 @@ Defined in: ridb\_core.d.ts:962
 
 > `readonly` **collection\_count**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:897
+Defined in: ridb\_core.d.ts:949
 
 #### Parameters
 
@@ -1498,7 +1498,7 @@ Defined in: ridb\_core.d.ts:897
 
 > `readonly` **collection\_create**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:900
+Defined in: ridb\_core.d.ts:952
 
 #### Parameters
 
@@ -1520,7 +1520,7 @@ Defined in: ridb\_core.d.ts:900
 
 > `readonly` **collection\_delete**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:901
+Defined in: ridb\_core.d.ts:953
 
 #### Parameters
 
@@ -1542,7 +1542,7 @@ Defined in: ridb\_core.d.ts:901
 
 > `readonly` **collection\_find**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:895
+Defined in: ridb\_core.d.ts:947
 
 #### Parameters
 
@@ -1568,7 +1568,7 @@ Defined in: ridb\_core.d.ts:895
 
 > `readonly` **collection\_findById**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:898
+Defined in: ridb\_core.d.ts:950
 
 #### Parameters
 
@@ -1590,7 +1590,7 @@ Defined in: ridb\_core.d.ts:898
 
 > `readonly` **collection\_name**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:893
+Defined in: ridb\_core.d.ts:945
 
 #### Parameters
 
@@ -1612,7 +1612,7 @@ Defined in: ridb\_core.d.ts:893
 
 > `readonly` **collection\_parse\_query\_options**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:896
+Defined in: ridb\_core.d.ts:948
 
 #### Parameters
 
@@ -1638,7 +1638,7 @@ Defined in: ridb\_core.d.ts:896
 
 > `readonly` **collection\_schema**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:894
+Defined in: ridb\_core.d.ts:946
 
 #### Parameters
 
@@ -1660,7 +1660,7 @@ Defined in: ridb\_core.d.ts:894
 
 > `readonly` **collection\_update**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:899
+Defined in: ridb\_core.d.ts:951
 
 #### Parameters
 
@@ -1682,7 +1682,7 @@ Defined in: ridb\_core.d.ts:899
 
 > `readonly` **corestorage\_getIndexes**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:903
+Defined in: ridb\_core.d.ts:937
 
 #### Parameters
 
@@ -1712,7 +1712,7 @@ Defined in: ridb\_core.d.ts:903
 
 > `readonly` **corestorage\_getPrimaryKeyTyped**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:902
+Defined in: ridb\_core.d.ts:936
 
 #### Parameters
 
@@ -1738,7 +1738,7 @@ Defined in: ridb\_core.d.ts:902
 
 > `readonly` **corestorage\_matchesQuery**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:904
+Defined in: ridb\_core.d.ts:938
 
 #### Parameters
 
@@ -1768,7 +1768,7 @@ Defined in: ridb\_core.d.ts:904
 
 > `readonly` **corestorage\_new**: () => `number`
 
-Defined in: ridb\_core.d.ts:912
+Defined in: ridb\_core.d.ts:942
 
 #### Returns
 
@@ -1780,7 +1780,7 @@ Defined in: ridb\_core.d.ts:912
 
 > `readonly` **database\_authenticate**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:971
+Defined in: ridb\_core.d.ts:915
 
 #### Parameters
 
@@ -1806,7 +1806,7 @@ Defined in: ridb\_core.d.ts:971
 
 > `readonly` **database\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:969
+Defined in: ridb\_core.d.ts:913
 
 #### Parameters
 
@@ -1824,7 +1824,7 @@ Defined in: ridb\_core.d.ts:969
 
 > `readonly` **database\_collections**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:972
+Defined in: ridb\_core.d.ts:916
 
 #### Parameters
 
@@ -1846,7 +1846,7 @@ Defined in: ridb\_core.d.ts:972
 
 > `readonly` **database\_create**: (`a`, `b`, `c`, `d`, `e`, `f`, `g`, `h`, `i`) => `number`
 
-Defined in: ridb\_core.d.ts:973
+Defined in: ridb\_core.d.ts:917
 
 #### Parameters
 
@@ -1896,7 +1896,7 @@ Defined in: ridb\_core.d.ts:973
 
 > `readonly` **database\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:968
+Defined in: ridb\_core.d.ts:912
 
 #### Parameters
 
@@ -1914,7 +1914,7 @@ Defined in: ridb\_core.d.ts:968
 
 > `readonly` **database\_started**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:970
+Defined in: ridb\_core.d.ts:914
 
 #### Parameters
 
@@ -1932,7 +1932,7 @@ Defined in: ridb\_core.d.ts:970
 
 > `readonly` **indexdb\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:890
+Defined in: ridb\_core.d.ts:934
 
 #### Parameters
 
@@ -1950,7 +1950,7 @@ Defined in: ridb\_core.d.ts:890
 
 > `readonly` **indexdb\_count**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:889
+Defined in: ridb\_core.d.ts:933
 
 #### Parameters
 
@@ -1984,7 +1984,7 @@ Defined in: ridb\_core.d.ts:889
 
 > `readonly` **indexdb\_create**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:885
+Defined in: ridb\_core.d.ts:929
 
 #### Parameters
 
@@ -2010,7 +2010,7 @@ Defined in: ridb\_core.d.ts:885
 
 > `readonly` **indexdb\_find**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:887
+Defined in: ridb\_core.d.ts:931
 
 #### Parameters
 
@@ -2044,7 +2044,7 @@ Defined in: ridb\_core.d.ts:887
 
 > `readonly` **indexdb\_findDocumentById**: (`a`, `b`, `c`, `d`) => `number`
 
-Defined in: ridb\_core.d.ts:888
+Defined in: ridb\_core.d.ts:932
 
 #### Parameters
 
@@ -2074,7 +2074,37 @@ Defined in: ridb\_core.d.ts:888
 
 > `readonly` **indexdb\_get\_store**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:884
+Defined in: ridb\_core.d.ts:927
+
+#### Parameters
+
+##### a
+
+`number`
+
+##### b
+
+`number`
+
+##### c
+
+`number`
+
+##### d
+
+`number`
+
+#### Returns
+
+`void`
+
+***
+
+### indexdb\_get\_store\_readonly()
+
+> `readonly` **indexdb\_get\_store\_readonly**: (`a`, `b`, `c`, `d`) => `void`
+
+Defined in: ridb\_core.d.ts:928
 
 #### Parameters
 
@@ -2104,7 +2134,7 @@ Defined in: ridb\_core.d.ts:884
 
 > `readonly` **indexdb\_get\_stores**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:883
+Defined in: ridb\_core.d.ts:926
 
 #### Parameters
 
@@ -2126,7 +2156,7 @@ Defined in: ridb\_core.d.ts:883
 
 > `readonly` **indexdb\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:891
+Defined in: ridb\_core.d.ts:935
 
 #### Parameters
 
@@ -2144,7 +2174,7 @@ Defined in: ridb\_core.d.ts:891
 
 > `readonly` **indexdb\_write**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:886
+Defined in: ridb\_core.d.ts:930
 
 #### Parameters
 
@@ -2166,7 +2196,7 @@ Defined in: ridb\_core.d.ts:886
 
 > `readonly` **inmemory\_close**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:957
+Defined in: ridb\_core.d.ts:903
 
 #### Parameters
 
@@ -2184,7 +2214,7 @@ Defined in: ridb\_core.d.ts:957
 
 > `readonly` **inmemory\_count**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:956
+Defined in: ridb\_core.d.ts:902
 
 #### Parameters
 
@@ -2218,7 +2248,7 @@ Defined in: ridb\_core.d.ts:956
 
 > `readonly` **inmemory\_create**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:952
+Defined in: ridb\_core.d.ts:898
 
 #### Parameters
 
@@ -2244,7 +2274,7 @@ Defined in: ridb\_core.d.ts:952
 
 > `readonly` **inmemory\_find**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:954
+Defined in: ridb\_core.d.ts:900
 
 #### Parameters
 
@@ -2278,7 +2308,7 @@ Defined in: ridb\_core.d.ts:954
 
 > `readonly` **inmemory\_findDocumentById**: (`a`, `b`, `c`, `d`) => `number`
 
-Defined in: ridb\_core.d.ts:955
+Defined in: ridb\_core.d.ts:901
 
 #### Parameters
 
@@ -2308,7 +2338,7 @@ Defined in: ridb\_core.d.ts:955
 
 > `readonly` **inmemory\_start**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:958
+Defined in: ridb\_core.d.ts:904
 
 #### Parameters
 
@@ -2326,7 +2356,7 @@ Defined in: ridb\_core.d.ts:958
 
 > `readonly` **inmemory\_write**: (`a`, `b`) => `number`
 
-Defined in: ridb\_core.d.ts:953
+Defined in: ridb\_core.d.ts:899
 
 #### Parameters
 
@@ -2348,7 +2378,7 @@ Defined in: ridb\_core.d.ts:953
 
 > `readonly` **is\_debug\_mode**: () => `number`
 
-Defined in: ridb\_core.d.ts:960
+Defined in: ridb\_core.d.ts:896
 
 #### Returns
 
@@ -2360,7 +2390,7 @@ Defined in: ridb\_core.d.ts:960
 
 > `readonly` **main\_js**: () => `void`
 
-Defined in: ridb\_core.d.ts:959
+Defined in: ridb\_core.d.ts:895
 
 #### Returns
 
@@ -2380,7 +2410,7 @@ Defined in: ridb\_core.d.ts:869
 
 > `readonly` **operation\_collection**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:906
+Defined in: ridb\_core.d.ts:1004
 
 #### Parameters
 
@@ -2402,7 +2432,7 @@ Defined in: ridb\_core.d.ts:906
 
 > `readonly` **operation\_data**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:908
+Defined in: ridb\_core.d.ts:1006
 
 #### Parameters
 
@@ -2420,7 +2450,7 @@ Defined in: ridb\_core.d.ts:908
 
 > `readonly` **operation\_opType**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:907
+Defined in: ridb\_core.d.ts:1005
 
 #### Parameters
 
@@ -2438,7 +2468,7 @@ Defined in: ridb\_core.d.ts:907
 
 > `readonly` **operation\_primaryKey**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:910
+Defined in: ridb\_core.d.ts:1008
 
 #### Parameters
 
@@ -2456,7 +2486,7 @@ Defined in: ridb\_core.d.ts:910
 
 > `readonly` **operation\_primaryKeyField**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:909
+Defined in: ridb\_core.d.ts:1007
 
 #### Parameters
 
@@ -2474,7 +2504,7 @@ Defined in: ridb\_core.d.ts:909
 
 > `readonly` **operation\_primaryKeyIndex**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:911
+Defined in: ridb\_core.d.ts:1009
 
 #### Parameters
 
@@ -2496,7 +2526,7 @@ Defined in: ridb\_core.d.ts:911
 
 > `readonly` **property\_is\_valid**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:871
+Defined in: ridb\_core.d.ts:992
 
 #### Parameters
 
@@ -2518,7 +2548,7 @@ Defined in: ridb\_core.d.ts:871
 
 > `readonly` **property\_items**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:873
+Defined in: ridb\_core.d.ts:994
 
 #### Parameters
 
@@ -2540,7 +2570,7 @@ Defined in: ridb\_core.d.ts:873
 
 > `readonly` **property\_maxItems**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:874
+Defined in: ridb\_core.d.ts:995
 
 #### Parameters
 
@@ -2562,7 +2592,7 @@ Defined in: ridb\_core.d.ts:874
 
 > `readonly` **property\_maxLength**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:876
+Defined in: ridb\_core.d.ts:997
 
 #### Parameters
 
@@ -2584,7 +2614,7 @@ Defined in: ridb\_core.d.ts:876
 
 > `readonly` **property\_minItems**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:875
+Defined in: ridb\_core.d.ts:996
 
 #### Parameters
 
@@ -2606,7 +2636,7 @@ Defined in: ridb\_core.d.ts:875
 
 > `readonly` **property\_minLength**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:877
+Defined in: ridb\_core.d.ts:998
 
 #### Parameters
 
@@ -2628,7 +2658,7 @@ Defined in: ridb\_core.d.ts:877
 
 > `readonly` **property\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:878
+Defined in: ridb\_core.d.ts:999
 
 #### Parameters
 
@@ -2650,7 +2680,7 @@ Defined in: ridb\_core.d.ts:878
 
 > `readonly` **property\_type**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:872
+Defined in: ridb\_core.d.ts:993
 
 #### Parameters
 
@@ -2668,7 +2698,7 @@ Defined in: ridb\_core.d.ts:872
 
 > `readonly` **query\_get**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:920
+Defined in: ridb\_core.d.ts:960
 
 #### Parameters
 
@@ -2698,7 +2728,7 @@ Defined in: ridb\_core.d.ts:920
 
 > `readonly` **query\_get\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:917
+Defined in: ridb\_core.d.ts:957
 
 #### Parameters
 
@@ -2720,7 +2750,7 @@ Defined in: ridb\_core.d.ts:917
 
 > `readonly` **query\_has\_or\_operator**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:921
+Defined in: ridb\_core.d.ts:961
 
 #### Parameters
 
@@ -2738,7 +2768,7 @@ Defined in: ridb\_core.d.ts:921
 
 > `readonly` **query\_new**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:915
+Defined in: ridb\_core.d.ts:955
 
 #### Parameters
 
@@ -2764,7 +2794,7 @@ Defined in: ridb\_core.d.ts:915
 
 > `readonly` **query\_parse**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:918
+Defined in: ridb\_core.d.ts:958
 
 #### Parameters
 
@@ -2786,7 +2816,7 @@ Defined in: ridb\_core.d.ts:918
 
 > `readonly` **query\_process\_query**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:919
+Defined in: ridb\_core.d.ts:959
 
 #### Parameters
 
@@ -2812,7 +2842,7 @@ Defined in: ridb\_core.d.ts:919
 
 > `readonly` **query\_query**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:916
+Defined in: ridb\_core.d.ts:956
 
 #### Parameters
 
@@ -2834,7 +2864,7 @@ Defined in: ridb\_core.d.ts:916
 
 > `readonly` **queryoptions\_limit**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:975
+Defined in: ridb\_core.d.ts:940
 
 #### Parameters
 
@@ -2856,7 +2886,7 @@ Defined in: ridb\_core.d.ts:975
 
 > `readonly` **queryoptions\_offset**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:976
+Defined in: ridb\_core.d.ts:941
 
 #### Parameters
 
@@ -2878,7 +2908,7 @@ Defined in: ridb\_core.d.ts:976
 
 > `readonly` **ridberror\_authentication**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:992
+Defined in: ridb\_core.d.ts:878
 
 #### Parameters
 
@@ -2904,7 +2934,7 @@ Defined in: ridb\_core.d.ts:992
 
 > `readonly` **ridberror\_code**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:987
+Defined in: ridb\_core.d.ts:873
 
 #### Parameters
 
@@ -2922,7 +2952,7 @@ Defined in: ridb\_core.d.ts:987
 
 > `readonly` **ridberror\_error**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:990
+Defined in: ridb\_core.d.ts:876
 
 #### Parameters
 
@@ -2948,7 +2978,7 @@ Defined in: ridb\_core.d.ts:990
 
 > `readonly` **ridberror\_from**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:989
+Defined in: ridb\_core.d.ts:875
 
 #### Parameters
 
@@ -2966,7 +2996,7 @@ Defined in: ridb\_core.d.ts:989
 
 > `readonly` **ridberror\_hook**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:995
+Defined in: ridb\_core.d.ts:881
 
 #### Parameters
 
@@ -2992,7 +3022,7 @@ Defined in: ridb\_core.d.ts:995
 
 > `readonly` **ridberror\_message**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:988
+Defined in: ridb\_core.d.ts:874
 
 #### Parameters
 
@@ -3014,7 +3044,7 @@ Defined in: ridb\_core.d.ts:988
 
 > `readonly` **ridberror\_new**: (`a`, `b`, `c`, `d`, `e`) => `number`
 
-Defined in: ridb\_core.d.ts:985
+Defined in: ridb\_core.d.ts:871
 
 #### Parameters
 
@@ -3048,7 +3078,7 @@ Defined in: ridb\_core.d.ts:985
 
 > `readonly` **ridberror\_query**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:991
+Defined in: ridb\_core.d.ts:877
 
 #### Parameters
 
@@ -3074,7 +3104,7 @@ Defined in: ridb\_core.d.ts:991
 
 > `readonly` **ridberror\_serialisation**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:993
+Defined in: ridb\_core.d.ts:879
 
 #### Parameters
 
@@ -3100,7 +3130,7 @@ Defined in: ridb\_core.d.ts:993
 
 > `readonly` **ridberror\_type**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:986
+Defined in: ridb\_core.d.ts:872
 
 #### Parameters
 
@@ -3122,7 +3152,7 @@ Defined in: ridb\_core.d.ts:986
 
 > `readonly` **ridberror\_validation**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:994
+Defined in: ridb\_core.d.ts:880
 
 #### Parameters
 
@@ -3148,7 +3178,7 @@ Defined in: ridb\_core.d.ts:994
 
 > `readonly` **schema\_create**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:999
+Defined in: ridb\_core.d.ts:885
 
 #### Parameters
 
@@ -3170,7 +3200,7 @@ Defined in: ridb\_core.d.ts:999
 
 > `readonly` **schema\_encrypted**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1004
+Defined in: ridb\_core.d.ts:890
 
 #### Parameters
 
@@ -3192,7 +3222,7 @@ Defined in: ridb\_core.d.ts:1004
 
 > `readonly` **schema\_indexes**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1003
+Defined in: ridb\_core.d.ts:889
 
 #### Parameters
 
@@ -3214,7 +3244,7 @@ Defined in: ridb\_core.d.ts:1003
 
 > `readonly` **schema\_is\_valid**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:998
+Defined in: ridb\_core.d.ts:884
 
 #### Parameters
 
@@ -3236,7 +3266,7 @@ Defined in: ridb\_core.d.ts:998
 
 > `readonly` **schema\_primaryKey**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1001
+Defined in: ridb\_core.d.ts:887
 
 #### Parameters
 
@@ -3258,7 +3288,7 @@ Defined in: ridb\_core.d.ts:1001
 
 > `readonly` **schema\_properties**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1005
+Defined in: ridb\_core.d.ts:891
 
 #### Parameters
 
@@ -3280,7 +3310,7 @@ Defined in: ridb\_core.d.ts:1005
 
 > `readonly` **schema\_type**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1002
+Defined in: ridb\_core.d.ts:888
 
 #### Parameters
 
@@ -3302,7 +3332,7 @@ Defined in: ridb\_core.d.ts:1002
 
 > `readonly` **schema\_validate**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:997
+Defined in: ridb\_core.d.ts:883
 
 #### Parameters
 
@@ -3328,7 +3358,7 @@ Defined in: ridb\_core.d.ts:997
 
 > `readonly` **schema\_version**: (`a`) => `number`
 
-Defined in: ridb\_core.d.ts:1000
+Defined in: ridb\_core.d.ts:886
 
 #### Parameters
 
@@ -3346,7 +3376,7 @@ Defined in: ridb\_core.d.ts:1000
 
 > `readonly` **wasm\_bindgen\_\_convert\_\_closures\_\_invoke0\_mut\_\_hff00333f3d941090**: (`a`, `b`) => `void`
 
-Defined in: ridb\_core.d.ts:1027
+Defined in: ridb\_core.d.ts:1028
 
 #### Parameters
 
@@ -3368,7 +3398,7 @@ Defined in: ridb\_core.d.ts:1027
 
 > `readonly` **wasm\_bindgen\_\_convert\_\_closures\_\_invoke2\_mut\_\_h97988f5fa0547d24**: (`a`, `b`, `c`, `d`) => `void`
 
-Defined in: ridb\_core.d.ts:1029
+Defined in: ridb\_core.d.ts:1030
 
 #### Parameters
 
@@ -3398,7 +3428,7 @@ Defined in: ridb\_core.d.ts:1029
 
 > `readonly` **wasm\_bindgen\_\_convert\_\_closures\_\_invoke3\_mut\_\_h703f9c33fd3008bf**: (`a`, `b`, `c`, `d`, `e`) => `void`
 
-Defined in: ridb\_core.d.ts:1028
+Defined in: ridb\_core.d.ts:1029
 
 #### Parameters
 
@@ -3432,7 +3462,7 @@ Defined in: ridb\_core.d.ts:1028
 
 > `readonly` **wasmbindgentestcontext\_args**: (`a`, `b`, `c`) => `void`
 
-Defined in: ridb\_core.d.ts:1011
+Defined in: ridb\_core.d.ts:1012
 
 #### Parameters
 
@@ -3458,7 +3488,7 @@ Defined in: ridb\_core.d.ts:1011
 
 > `readonly` **wasmbindgentestcontext\_new**: () => `number`
 
-Defined in: ridb\_core.d.ts:1010
+Defined in: ridb\_core.d.ts:1011
 
 #### Returns
 
@@ -3470,7 +3500,7 @@ Defined in: ridb\_core.d.ts:1010
 
 > `readonly` **wasmbindgentestcontext\_run**: (`a`, `b`, `c`) => `number`
 
-Defined in: ridb\_core.d.ts:1012
+Defined in: ridb\_core.d.ts:1013
 
 #### Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/AnyVersionGreaterThan1.md
+++ b/docs/@trust0/ridb-core/type-aliases/AnyVersionGreaterThan1.md
@@ -8,7 +8,7 @@
 
 > **AnyVersionGreaterThan1**\<`T`\> = `true` *extends* `{ [K in keyof T]: IsVersionGreaterThan0<T[K]["version"]> }`\[keyof `T`\] ? `true` : `false`
 
-Defined in: ridb\_core.d.ts:199
+Defined in: ridb\_core.d.ts:478
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/AnyVersionGreaterThan1.md
+++ b/docs/@trust0/ridb-core/type-aliases/AnyVersionGreaterThan1.md
@@ -8,7 +8,7 @@
 
 > **AnyVersionGreaterThan1**\<`T`\> = `true` *extends* `{ [K in keyof T]: IsVersionGreaterThan0<T[K]["version"]> }`\[keyof `T`\] ? `true` : `false`
 
-Defined in: ridb\_core.d.ts:468
+Defined in: ridb\_core.d.ts:402
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/AnyVersionGreaterThan1.md
+++ b/docs/@trust0/ridb-core/type-aliases/AnyVersionGreaterThan1.md
@@ -8,7 +8,7 @@
 
 > **AnyVersionGreaterThan1**\<`T`\> = `true` *extends* `{ [K in keyof T]: IsVersionGreaterThan0<T[K]["version"]> }`\[keyof `T`\] ? `true` : `false`
 
-Defined in: ridb\_core.d.ts:478
+Defined in: ridb\_core.d.ts:468
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/AnyVersionGreaterThan1.md
+++ b/docs/@trust0/ridb-core/type-aliases/AnyVersionGreaterThan1.md
@@ -8,7 +8,7 @@
 
 > **AnyVersionGreaterThan1**\<`T`\> = `true` *extends* `{ [K in keyof T]: IsVersionGreaterThan0<T[K]["version"]> }`\[keyof `T`\] ? `true` : `false`
 
-Defined in: ridb\_core.d.ts:402
+Defined in: ridb\_core.d.ts:727
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/BasePluginOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/BasePluginOptions.md
@@ -8,7 +8,7 @@
 
 > **BasePluginOptions** = `object`
 
-Defined in: ridb\_core.d.ts:238
+Defined in: ridb\_core.d.ts:517
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: ridb\_core.d.ts:238
 
 > `optional` **docCreateHook**: [`Hook`](Hook.md)
 
-Defined in: ridb\_core.d.ts:239
+Defined in: ridb\_core.d.ts:518
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: ridb\_core.d.ts:239
 
 > `optional` **docRecoverHook**: [`Hook`](Hook.md)
 
-Defined in: ridb\_core.d.ts:240
+Defined in: ridb\_core.d.ts:519

--- a/docs/@trust0/ridb-core/type-aliases/BasePluginOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/BasePluginOptions.md
@@ -8,7 +8,7 @@
 
 > **BasePluginOptions** = `object`
 
-Defined in: ridb\_core.d.ts:640
+Defined in: ridb\_core.d.ts:383
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: ridb\_core.d.ts:640
 
 > `optional` **docCreateHook**: [`Hook`](Hook.md)
 
-Defined in: ridb\_core.d.ts:641
+Defined in: ridb\_core.d.ts:384
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: ridb\_core.d.ts:641
 
 > `optional` **docRecoverHook**: [`Hook`](Hook.md)
 
-Defined in: ridb\_core.d.ts:642
+Defined in: ridb\_core.d.ts:385

--- a/docs/@trust0/ridb-core/type-aliases/BasePluginOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/BasePluginOptions.md
@@ -8,7 +8,7 @@
 
 > **BasePluginOptions** = `object`
 
-Defined in: ridb\_core.d.ts:517
+Defined in: ridb\_core.d.ts:382
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: ridb\_core.d.ts:517
 
 > `optional` **docCreateHook**: [`Hook`](Hook.md)
 
-Defined in: ridb\_core.d.ts:518
+Defined in: ridb\_core.d.ts:383
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: ridb\_core.d.ts:518
 
 > `optional` **docRecoverHook**: [`Hook`](Hook.md)
 
-Defined in: ridb\_core.d.ts:519
+Defined in: ridb\_core.d.ts:384

--- a/docs/@trust0/ridb-core/type-aliases/BasePluginOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/BasePluginOptions.md
@@ -8,7 +8,7 @@
 
 > **BasePluginOptions** = `object`
 
-Defined in: ridb\_core.d.ts:382
+Defined in: ridb\_core.d.ts:640
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: ridb\_core.d.ts:382
 
 > `optional` **docCreateHook**: [`Hook`](Hook.md)
 
-Defined in: ridb\_core.d.ts:383
+Defined in: ridb\_core.d.ts:641
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: ridb\_core.d.ts:383
 
 > `optional` **docRecoverHook**: [`Hook`](Hook.md)
 
-Defined in: ridb\_core.d.ts:384
+Defined in: ridb\_core.d.ts:642

--- a/docs/@trust0/ridb-core/type-aliases/BaseStorageOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/BaseStorageOptions.md
@@ -8,7 +8,7 @@
 
 > **BaseStorageOptions** = `object`
 
-Defined in: ridb\_core.d.ts:398
+Defined in: ridb\_core.d.ts:195
 
 ## Index Signature
 

--- a/docs/@trust0/ridb-core/type-aliases/BaseStorageOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/BaseStorageOptions.md
@@ -8,7 +8,7 @@
 
 > **BaseStorageOptions** = `object`
 
-Defined in: ridb\_core.d.ts:235
+Defined in: ridb\_core.d.ts:493
 
 ## Index Signature
 

--- a/docs/@trust0/ridb-core/type-aliases/BaseStorageOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/BaseStorageOptions.md
@@ -8,7 +8,7 @@
 
 > **BaseStorageOptions** = `object`
 
-Defined in: ridb\_core.d.ts:493
+Defined in: ridb\_core.d.ts:236
 
 ## Index Signature
 

--- a/docs/@trust0/ridb-core/type-aliases/BaseStorageOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/BaseStorageOptions.md
@@ -8,7 +8,7 @@
 
 > **BaseStorageOptions** = `object`
 
-Defined in: ridb\_core.d.ts:195
+Defined in: ridb\_core.d.ts:235
 
 ## Index Signature
 

--- a/docs/@trust0/ridb-core/type-aliases/CreateDoc.md
+++ b/docs/@trust0/ridb-core/type-aliases/CreateDoc.md
@@ -8,7 +8,7 @@
 
 > **CreateDoc**\<`T`\> = `{ [K in keyof T["properties"] as IsOptional<T["properties"][K]> extends true ? K : never]?: ExtractType<T["properties"][K]["type"]> }` & `{ [K in keyof T["properties"] as IsOptional<T["properties"][K]> extends true ? never : K]: ExtractType<T["properties"][K]["type"]> }` & `object`
 
-Defined in: ridb\_core.d.ts:331
+Defined in: ridb\_core.d.ts:128
 
 CreateDoc is a utility type for document creation that properly handles required vs optional fields
 during the creation process. Fields with default values or required: false become optional.

--- a/docs/@trust0/ridb-core/type-aliases/CreateDoc.md
+++ b/docs/@trust0/ridb-core/type-aliases/CreateDoc.md
@@ -8,7 +8,7 @@
 
 > **CreateDoc**\<`T`\> = `{ [K in keyof T["properties"] as IsOptional<T["properties"][K]> extends true ? K : never]?: ExtractType<T["properties"][K]["type"]> }` & `{ [K in keyof T["properties"] as IsOptional<T["properties"][K]> extends true ? never : K]: ExtractType<T["properties"][K]["type"]> }` & `object`
 
-Defined in: ridb\_core.d.ts:244
+Defined in: ridb\_core.d.ts:483
 
 CreateDoc is a utility type for document creation that properly handles required vs optional fields
 during the creation process. Fields with default values or required: false become optional.

--- a/docs/@trust0/ridb-core/type-aliases/CreateDoc.md
+++ b/docs/@trust0/ridb-core/type-aliases/CreateDoc.md
@@ -8,7 +8,7 @@
 
 > **CreateDoc**\<`T`\> = `{ [K in keyof T["properties"] as IsOptional<T["properties"][K]> extends true ? K : never]?: ExtractType<T["properties"][K]["type"]> }` & `{ [K in keyof T["properties"] as IsOptional<T["properties"][K]> extends true ? never : K]: ExtractType<T["properties"][K]["type"]> }` & `object`
 
-Defined in: ridb\_core.d.ts:128
+Defined in: ridb\_core.d.ts:244
 
 CreateDoc is a utility type for document creation that properly handles required vs optional fields
 during the creation process. Fields with default values or required: false become optional.

--- a/docs/@trust0/ridb-core/type-aliases/CreateStorage.md
+++ b/docs/@trust0/ridb-core/type-aliases/CreateStorage.md
@@ -8,7 +8,7 @@
 
 > **CreateStorage** = \<`T`\>(`records`) => `Promise`\<[`BaseStorage`](../classes/BaseStorage.md)\<`T`\>\>
 
-Defined in: ridb\_core.d.ts:617
+Defined in: ridb\_core.d.ts:360
 
 Represents a function type for creating storage with the provided schema type records.
 

--- a/docs/@trust0/ridb-core/type-aliases/CreateStorage.md
+++ b/docs/@trust0/ridb-core/type-aliases/CreateStorage.md
@@ -8,7 +8,7 @@
 
 > **CreateStorage** = \<`T`\>(`records`) => `Promise`\<[`BaseStorage`](../classes/BaseStorage.md)\<`T`\>\>
 
-Defined in: ridb\_core.d.ts:359
+Defined in: ridb\_core.d.ts:617
 
 Represents a function type for creating storage with the provided schema type records.
 

--- a/docs/@trust0/ridb-core/type-aliases/CreateStorage.md
+++ b/docs/@trust0/ridb-core/type-aliases/CreateStorage.md
@@ -8,7 +8,7 @@
 
 > **CreateStorage** = \<`T`\>(`records`) => `Promise`\<[`BaseStorage`](../classes/BaseStorage.md)\<`T`\>\>
 
-Defined in: ridb\_core.d.ts:716
+Defined in: ridb\_core.d.ts:359
 
 Represents a function type for creating storage with the provided schema type records.
 

--- a/docs/@trust0/ridb-core/type-aliases/CreateStorage.md
+++ b/docs/@trust0/ridb-core/type-aliases/CreateStorage.md
@@ -8,7 +8,7 @@
 
 > **CreateStorage** = \<`T`\>(`records`) => `Promise`\<[`BaseStorage`](../classes/BaseStorage.md)\<`T`\>\>
 
-Defined in: ridb\_core.d.ts:681
+Defined in: ridb\_core.d.ts:716
 
 Represents a function type for creating storage with the provided schema type records.
 

--- a/docs/@trust0/ridb-core/type-aliases/Doc.md
+++ b/docs/@trust0/ridb-core/type-aliases/Doc.md
@@ -8,7 +8,7 @@
 
 > **Doc**\<`T`\> = `{ [K in keyof T["properties"]]: ExtractType<T["properties"][K]["type"]> }` & `object`
 
-Defined in: ridb\_core.d.ts:229
+Defined in: ridb\_core.d.ts:468
 
 Doc is a utility type that transforms a schema type into a document type where each property is mapped to its extracted type.
 

--- a/docs/@trust0/ridb-core/type-aliases/Doc.md
+++ b/docs/@trust0/ridb-core/type-aliases/Doc.md
@@ -8,7 +8,7 @@
 
 > **Doc**\<`T`\> = `{ [K in keyof T["properties"]]: ExtractType<T["properties"][K]["type"]> }` & `object`
 
-Defined in: ridb\_core.d.ts:316
+Defined in: ridb\_core.d.ts:113
 
 Doc is a utility type that transforms a schema type into a document type where each property is mapped to its extracted type.
 

--- a/docs/@trust0/ridb-core/type-aliases/Doc.md
+++ b/docs/@trust0/ridb-core/type-aliases/Doc.md
@@ -8,7 +8,7 @@
 
 > **Doc**\<`T`\> = `{ [K in keyof T["properties"]]: ExtractType<T["properties"][K]["type"]> }` & `object`
 
-Defined in: ridb\_core.d.ts:113
+Defined in: ridb\_core.d.ts:229
 
 Doc is a utility type that transforms a schema type into a document type where each property is mapped to its extracted type.
 

--- a/docs/@trust0/ridb-core/type-aliases/EnumerateFrom1To.md
+++ b/docs/@trust0/ridb-core/type-aliases/EnumerateFrom1To.md
@@ -8,7 +8,7 @@
 
 > **EnumerateFrom1To**\<`N`\> = `Exclude`\<[`EnumerateUpTo`](EnumerateUpTo.md)\<`N`\>, `0`\> \| `N` *extends* `0` ? `never` : `N`
 
-Defined in: ridb\_core.d.ts:470
+Defined in: ridb\_core.d.ts:460
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/EnumerateFrom1To.md
+++ b/docs/@trust0/ridb-core/type-aliases/EnumerateFrom1To.md
@@ -8,7 +8,7 @@
 
 > **EnumerateFrom1To**\<`N`\> = `Exclude`\<[`EnumerateUpTo`](EnumerateUpTo.md)\<`N`\>, `0`\> \| `N` *extends* `0` ? `never` : `N`
 
-Defined in: ridb\_core.d.ts:460
+Defined in: ridb\_core.d.ts:394
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/EnumerateFrom1To.md
+++ b/docs/@trust0/ridb-core/type-aliases/EnumerateFrom1To.md
@@ -8,7 +8,7 @@
 
 > **EnumerateFrom1To**\<`N`\> = `Exclude`\<[`EnumerateUpTo`](EnumerateUpTo.md)\<`N`\>, `0`\> \| `N` *extends* `0` ? `never` : `N`
 
-Defined in: ridb\_core.d.ts:394
+Defined in: ridb\_core.d.ts:719
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/EnumerateFrom1To.md
+++ b/docs/@trust0/ridb-core/type-aliases/EnumerateFrom1To.md
@@ -8,7 +8,7 @@
 
 > **EnumerateFrom1To**\<`N`\> = `Exclude`\<[`EnumerateUpTo`](EnumerateUpTo.md)\<`N`\>, `0`\> \| `N` *extends* `0` ? `never` : `N`
 
-Defined in: ridb\_core.d.ts:191
+Defined in: ridb\_core.d.ts:470
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/EnumerateUpTo.md
+++ b/docs/@trust0/ridb-core/type-aliases/EnumerateUpTo.md
@@ -8,7 +8,7 @@
 
 > **EnumerateUpTo**\<`N`, `Acc`\> = `Acc`\[`"length"`\] *extends* `N` ? `Acc`\[`number`\] : `EnumerateUpTo`\<`N`, \[`...Acc`, `Acc`\[`"length"`\]\]\>
 
-Defined in: ridb\_core.d.ts:463
+Defined in: ridb\_core.d.ts:453
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/EnumerateUpTo.md
+++ b/docs/@trust0/ridb-core/type-aliases/EnumerateUpTo.md
@@ -8,7 +8,7 @@
 
 > **EnumerateUpTo**\<`N`, `Acc`\> = `Acc`\[`"length"`\] *extends* `N` ? `Acc`\[`number`\] : `EnumerateUpTo`\<`N`, \[`...Acc`, `Acc`\[`"length"`\]\]\>
 
-Defined in: ridb\_core.d.ts:453
+Defined in: ridb\_core.d.ts:387
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/EnumerateUpTo.md
+++ b/docs/@trust0/ridb-core/type-aliases/EnumerateUpTo.md
@@ -8,7 +8,7 @@
 
 > **EnumerateUpTo**\<`N`, `Acc`\> = `Acc`\[`"length"`\] *extends* `N` ? `Acc`\[`number`\] : `EnumerateUpTo`\<`N`, \[`...Acc`, `Acc`\[`"length"`\]\]\>
 
-Defined in: ridb\_core.d.ts:387
+Defined in: ridb\_core.d.ts:712
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/EnumerateUpTo.md
+++ b/docs/@trust0/ridb-core/type-aliases/EnumerateUpTo.md
@@ -8,7 +8,7 @@
 
 > **EnumerateUpTo**\<`N`, `Acc`\> = `Acc`\[`"length"`\] *extends* `N` ? `Acc`\[`number`\] : `EnumerateUpTo`\<`N`, \[`...Acc`, `Acc`\[`"length"`\]\]\>
 
-Defined in: ridb\_core.d.ts:184
+Defined in: ridb\_core.d.ts:463
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/ExtractType.md
+++ b/docs/@trust0/ridb-core/type-aliases/ExtractType.md
@@ -8,7 +8,7 @@
 
 > **ExtractType**\<`T`\> = `T` *extends* `"string"` ? `string` : `T` *extends* `"number"` ? `number` : `T` *extends* `"boolean"` ? `boolean` : `T` *extends* `"object"` ? `object` : `T` *extends* `"array"` ? `any`[] : `undefined`
 
-Defined in: ridb\_core.d.ts:91
+Defined in: ridb\_core.d.ts:207
 
 ExtractType is a utility type that maps a string representing a basic data type to the actual TypeScript type.
 

--- a/docs/@trust0/ridb-core/type-aliases/ExtractType.md
+++ b/docs/@trust0/ridb-core/type-aliases/ExtractType.md
@@ -8,7 +8,7 @@
 
 > **ExtractType**\<`T`\> = `T` *extends* `"string"` ? `string` : `T` *extends* `"number"` ? `number` : `T` *extends* `"boolean"` ? `boolean` : `T` *extends* `"object"` ? `object` : `T` *extends* `"array"` ? `any`[] : `undefined`
 
-Defined in: ridb\_core.d.ts:207
+Defined in: ridb\_core.d.ts:446
 
 ExtractType is a utility type that maps a string representing a basic data type to the actual TypeScript type.
 

--- a/docs/@trust0/ridb-core/type-aliases/ExtractType.md
+++ b/docs/@trust0/ridb-core/type-aliases/ExtractType.md
@@ -8,7 +8,7 @@
 
 > **ExtractType**\<`T`\> = `T` *extends* `"string"` ? `string` : `T` *extends* `"number"` ? `number` : `T` *extends* `"boolean"` ? `boolean` : `T` *extends* `"object"` ? `object` : `T` *extends* `"array"` ? `any`[] : `undefined`
 
-Defined in: ridb\_core.d.ts:294
+Defined in: ridb\_core.d.ts:91
 
 ExtractType is a utility type that maps a string representing a basic data type to the actual TypeScript type.
 

--- a/docs/@trust0/ridb-core/type-aliases/Hook.md
+++ b/docs/@trust0/ridb-core/type-aliases/Hook.md
@@ -8,7 +8,7 @@
 
 > **Hook** = (`schema`, `migration`, `doc`) => [`Doc`](Doc.md)\<[`SchemaType`](SchemaType.md)\>
 
-Defined in: ridb\_core.d.ts:232
+Defined in: ridb\_core.d.ts:511
 
 ## Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/Hook.md
+++ b/docs/@trust0/ridb-core/type-aliases/Hook.md
@@ -8,7 +8,7 @@
 
 > **Hook** = (`schema`, `migration`, `doc`) => [`Doc`](Doc.md)\<[`SchemaType`](SchemaType.md)\>
 
-Defined in: ridb\_core.d.ts:376
+Defined in: ridb\_core.d.ts:634
 
 ## Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/Hook.md
+++ b/docs/@trust0/ridb-core/type-aliases/Hook.md
@@ -8,7 +8,7 @@
 
 > **Hook** = (`schema`, `migration`, `doc`) => [`Doc`](Doc.md)\<[`SchemaType`](SchemaType.md)\>
 
-Defined in: ridb\_core.d.ts:511
+Defined in: ridb\_core.d.ts:376
 
 ## Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/Hook.md
+++ b/docs/@trust0/ridb-core/type-aliases/Hook.md
@@ -8,7 +8,7 @@
 
 > **Hook** = (`schema`, `migration`, `doc`) => [`Doc`](Doc.md)\<[`SchemaType`](SchemaType.md)\>
 
-Defined in: ridb\_core.d.ts:634
+Defined in: ridb\_core.d.ts:377
 
 ## Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/InOperator.md
+++ b/docs/@trust0/ridb-core/type-aliases/InOperator.md
@@ -8,7 +8,7 @@
 
 > **InOperator**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:403
+Defined in: ridb\_core.d.ts:360
 
 ## Type Parameters
 
@@ -22,4 +22,4 @@ Defined in: ridb\_core.d.ts:403
 
 > `optional` **$in**: `T`[]
 
-Defined in: ridb\_core.d.ts:403
+Defined in: ridb\_core.d.ts:360

--- a/docs/@trust0/ridb-core/type-aliases/InOperator.md
+++ b/docs/@trust0/ridb-core/type-aliases/InOperator.md
@@ -8,7 +8,7 @@
 
 > **InOperator**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:467
+Defined in: ridb\_core.d.ts:264
 
 ## Type Parameters
 
@@ -22,4 +22,4 @@ Defined in: ridb\_core.d.ts:467
 
 > `optional` **$in**: `T`[]
 
-Defined in: ridb\_core.d.ts:467
+Defined in: ridb\_core.d.ts:264

--- a/docs/@trust0/ridb-core/type-aliases/InOperator.md
+++ b/docs/@trust0/ridb-core/type-aliases/InOperator.md
@@ -8,7 +8,7 @@
 
 > **InOperator**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:360
+Defined in: ridb\_core.d.ts:559
 
 ## Type Parameters
 
@@ -22,4 +22,4 @@ Defined in: ridb\_core.d.ts:360
 
 > `optional` **$in**: `T`[]
 
-Defined in: ridb\_core.d.ts:360
+Defined in: ridb\_core.d.ts:559

--- a/docs/@trust0/ridb-core/type-aliases/InOperator.md
+++ b/docs/@trust0/ridb-core/type-aliases/InOperator.md
@@ -8,7 +8,7 @@
 
 > **InOperator**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:264
+Defined in: ridb\_core.d.ts:403
 
 ## Type Parameters
 
@@ -22,4 +22,4 @@ Defined in: ridb\_core.d.ts:264
 
 > `optional` **$in**: `T`[]
 
-Defined in: ridb\_core.d.ts:264
+Defined in: ridb\_core.d.ts:403

--- a/docs/@trust0/ridb-core/type-aliases/InternalsRecord.md
+++ b/docs/@trust0/ridb-core/type-aliases/InternalsRecord.md
@@ -8,7 +8,7 @@
 
 > **InternalsRecord** = `object`
 
-Defined in: ridb\_core.d.ts:279
+Defined in: ridb\_core.d.ts:76
 
 ## Index Signature
 

--- a/docs/@trust0/ridb-core/type-aliases/InternalsRecord.md
+++ b/docs/@trust0/ridb-core/type-aliases/InternalsRecord.md
@@ -8,7 +8,7 @@
 
 > **InternalsRecord** = `object`
 
-Defined in: ridb\_core.d.ts:192
+Defined in: ridb\_core.d.ts:431
 
 ## Index Signature
 

--- a/docs/@trust0/ridb-core/type-aliases/InternalsRecord.md
+++ b/docs/@trust0/ridb-core/type-aliases/InternalsRecord.md
@@ -8,7 +8,7 @@
 
 > **InternalsRecord** = `object`
 
-Defined in: ridb\_core.d.ts:76
+Defined in: ridb\_core.d.ts:192
 
 ## Index Signature
 

--- a/docs/@trust0/ridb-core/type-aliases/IsOptional.md
+++ b/docs/@trust0/ridb-core/type-aliases/IsOptional.md
@@ -8,7 +8,7 @@
 
 > **IsOptional**\<`T`\> = `T` *extends* `object` ? `T` *extends* `object` ? `false` : `true` : `true`
 
-Defined in: ridb\_core.d.ts:215
+Defined in: ridb\_core.d.ts:454
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/IsOptional.md
+++ b/docs/@trust0/ridb-core/type-aliases/IsOptional.md
@@ -8,7 +8,7 @@
 
 > **IsOptional**\<`T`\> = `T` *extends* `object` ? `T` *extends* `object` ? `false` : `true` : `true`
 
-Defined in: ridb\_core.d.ts:302
+Defined in: ridb\_core.d.ts:99
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/IsOptional.md
+++ b/docs/@trust0/ridb-core/type-aliases/IsOptional.md
@@ -8,7 +8,7 @@
 
 > **IsOptional**\<`T`\> = `T` *extends* `object` ? `T` *extends* `object` ? `false` : `true` : `true`
 
-Defined in: ridb\_core.d.ts:99
+Defined in: ridb\_core.d.ts:215
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/IsVersionGreaterThan0.md
+++ b/docs/@trust0/ridb-core/type-aliases/IsVersionGreaterThan0.md
@@ -8,7 +8,7 @@
 
 > **IsVersionGreaterThan0**\<`V`\> = `V` *extends* `0` ? `false` : `true`
 
-Defined in: ridb\_core.d.ts:195
+Defined in: ridb\_core.d.ts:474
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/IsVersionGreaterThan0.md
+++ b/docs/@trust0/ridb-core/type-aliases/IsVersionGreaterThan0.md
@@ -8,7 +8,7 @@
 
 > **IsVersionGreaterThan0**\<`V`\> = `V` *extends* `0` ? `false` : `true`
 
-Defined in: ridb\_core.d.ts:474
+Defined in: ridb\_core.d.ts:464
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/IsVersionGreaterThan0.md
+++ b/docs/@trust0/ridb-core/type-aliases/IsVersionGreaterThan0.md
@@ -8,7 +8,7 @@
 
 > **IsVersionGreaterThan0**\<`V`\> = `V` *extends* `0` ? `false` : `true`
 
-Defined in: ridb\_core.d.ts:464
+Defined in: ridb\_core.d.ts:398
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/IsVersionGreaterThan0.md
+++ b/docs/@trust0/ridb-core/type-aliases/IsVersionGreaterThan0.md
@@ -8,7 +8,7 @@
 
 > **IsVersionGreaterThan0**\<`V`\> = `V` *extends* `0` ? `false` : `true`
 
-Defined in: ridb\_core.d.ts:398
+Defined in: ridb\_core.d.ts:723
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/LogicalOperators.md
+++ b/docs/@trust0/ridb-core/type-aliases/LogicalOperators.md
@@ -8,7 +8,7 @@
 
 > **LogicalOperators**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:474
+Defined in: ridb\_core.d.ts:271
 
 ## Type Parameters
 
@@ -22,7 +22,7 @@ Defined in: ridb\_core.d.ts:474
 
 > `optional` **$and**: `Partial`\<[`QueryType`](QueryType.md)\<`T`\>\>[]
 
-Defined in: ridb\_core.d.ts:475
+Defined in: ridb\_core.d.ts:272
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: ridb\_core.d.ts:475
 
 > `optional` **$or**: `Partial`\<[`QueryType`](QueryType.md)\<`T`\>\>[]
 
-Defined in: ridb\_core.d.ts:476
+Defined in: ridb\_core.d.ts:273

--- a/docs/@trust0/ridb-core/type-aliases/LogicalOperators.md
+++ b/docs/@trust0/ridb-core/type-aliases/LogicalOperators.md
@@ -8,7 +8,7 @@
 
 > **LogicalOperators**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:367
+Defined in: ridb\_core.d.ts:566
 
 ## Type Parameters
 
@@ -22,7 +22,7 @@ Defined in: ridb\_core.d.ts:367
 
 > `optional` **$and**: `Partial`\<[`QueryType`](QueryType.md)\<`T`\>\>[]
 
-Defined in: ridb\_core.d.ts:368
+Defined in: ridb\_core.d.ts:567
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: ridb\_core.d.ts:368
 
 > `optional` **$or**: `Partial`\<[`QueryType`](QueryType.md)\<`T`\>\>[]
 
-Defined in: ridb\_core.d.ts:369
+Defined in: ridb\_core.d.ts:568

--- a/docs/@trust0/ridb-core/type-aliases/LogicalOperators.md
+++ b/docs/@trust0/ridb-core/type-aliases/LogicalOperators.md
@@ -8,7 +8,7 @@
 
 > **LogicalOperators**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:271
+Defined in: ridb\_core.d.ts:410
 
 ## Type Parameters
 
@@ -22,7 +22,7 @@ Defined in: ridb\_core.d.ts:271
 
 > `optional` **$and**: `Partial`\<[`QueryType`](QueryType.md)\<`T`\>\>[]
 
-Defined in: ridb\_core.d.ts:272
+Defined in: ridb\_core.d.ts:411
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: ridb\_core.d.ts:272
 
 > `optional` **$or**: `Partial`\<[`QueryType`](QueryType.md)\<`T`\>\>[]
 
-Defined in: ridb\_core.d.ts:273
+Defined in: ridb\_core.d.ts:412

--- a/docs/@trust0/ridb-core/type-aliases/LogicalOperators.md
+++ b/docs/@trust0/ridb-core/type-aliases/LogicalOperators.md
@@ -8,7 +8,7 @@
 
 > **LogicalOperators**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:410
+Defined in: ridb\_core.d.ts:367
 
 ## Type Parameters
 
@@ -22,7 +22,7 @@ Defined in: ridb\_core.d.ts:410
 
 > `optional` **$and**: `Partial`\<[`QueryType`](QueryType.md)\<`T`\>\>[]
 
-Defined in: ridb\_core.d.ts:411
+Defined in: ridb\_core.d.ts:368
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: ridb\_core.d.ts:411
 
 > `optional` **$or**: `Partial`\<[`QueryType`](QueryType.md)\<`T`\>\>[]
 
-Defined in: ridb\_core.d.ts:412
+Defined in: ridb\_core.d.ts:369

--- a/docs/@trust0/ridb-core/type-aliases/MigrationFunction.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationFunction.md
@@ -8,7 +8,7 @@
 
 > **MigrationFunction**\<`T`\> = (`doc`) => [`Doc`](Doc.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:408
+Defined in: ridb\_core.d.ts:733
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationFunction.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationFunction.md
@@ -8,7 +8,7 @@
 
 > **MigrationFunction**\<`T`\> = (`doc`) => [`Doc`](Doc.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:205
+Defined in: ridb\_core.d.ts:484
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationFunction.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationFunction.md
@@ -8,7 +8,7 @@
 
 > **MigrationFunction**\<`T`\> = (`doc`) => [`Doc`](Doc.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:474
+Defined in: ridb\_core.d.ts:408
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationFunction.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationFunction.md
@@ -8,7 +8,7 @@
 
 > **MigrationFunction**\<`T`\> = (`doc`) => [`Doc`](Doc.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:484
+Defined in: ridb\_core.d.ts:474
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchema.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchema.md
@@ -8,7 +8,7 @@
 
 > **MigrationPathsForSchema**\<`T`\> = `T`\[`"version"`\] *extends* `0` ? `object` : `{ [K in EnumerateFrom1To<T["version"]>]: MigrationFunction<T> }`
 
-Defined in: ridb\_core.d.ts:207
+Defined in: ridb\_core.d.ts:486
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchema.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchema.md
@@ -8,7 +8,7 @@
 
 > **MigrationPathsForSchema**\<`T`\> = `T`\[`"version"`\] *extends* `0` ? `object` : `{ [K in EnumerateFrom1To<T["version"]>]: MigrationFunction<T> }`
 
-Defined in: ridb\_core.d.ts:476
+Defined in: ridb\_core.d.ts:410
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchema.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchema.md
@@ -8,7 +8,7 @@
 
 > **MigrationPathsForSchema**\<`T`\> = `T`\[`"version"`\] *extends* `0` ? `object` : `{ [K in EnumerateFrom1To<T["version"]>]: MigrationFunction<T> }`
 
-Defined in: ridb\_core.d.ts:486
+Defined in: ridb\_core.d.ts:476
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchema.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchema.md
@@ -8,7 +8,7 @@
 
 > **MigrationPathsForSchema**\<`T`\> = `T`\[`"version"`\] *extends* `0` ? `object` : `{ [K in EnumerateFrom1To<T["version"]>]: MigrationFunction<T> }`
 
-Defined in: ridb\_core.d.ts:410
+Defined in: ridb\_core.d.ts:735
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchemas.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchemas.md
@@ -8,7 +8,7 @@
 
 > **MigrationPathsForSchemas**\<`T`\> = `{ [K in keyof T]: MigrationPathsForSchema<T[K]> }`
 
-Defined in: ridb\_core.d.ts:483
+Defined in: ridb\_core.d.ts:417
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchemas.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchemas.md
@@ -8,7 +8,7 @@
 
 > **MigrationPathsForSchemas**\<`T`\> = `{ [K in keyof T]: MigrationPathsForSchema<T[K]> }`
 
-Defined in: ridb\_core.d.ts:493
+Defined in: ridb\_core.d.ts:483
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchemas.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchemas.md
@@ -8,7 +8,7 @@
 
 > **MigrationPathsForSchemas**\<`T`\> = `{ [K in keyof T]: MigrationPathsForSchema<T[K]> }`
 
-Defined in: ridb\_core.d.ts:417
+Defined in: ridb\_core.d.ts:742
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchemas.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationPathsForSchemas.md
@@ -8,7 +8,7 @@
 
 > **MigrationPathsForSchemas**\<`T`\> = `{ [K in keyof T]: MigrationPathsForSchema<T[K]> }`
 
-Defined in: ridb\_core.d.ts:214
+Defined in: ridb\_core.d.ts:493
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationsParameter.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationsParameter.md
@@ -8,7 +8,7 @@
 
 > **MigrationsParameter**\<`T`\> = [`AnyVersionGreaterThan1`](AnyVersionGreaterThan1.md)\<`T`\> *extends* `true` ? `object` : `object`
 
-Defined in: ridb\_core.d.ts:499
+Defined in: ridb\_core.d.ts:489
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationsParameter.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationsParameter.md
@@ -8,7 +8,7 @@
 
 > **MigrationsParameter**\<`T`\> = [`AnyVersionGreaterThan1`](AnyVersionGreaterThan1.md)\<`T`\> *extends* `true` ? `object` : `object`
 
-Defined in: ridb\_core.d.ts:220
+Defined in: ridb\_core.d.ts:499
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationsParameter.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationsParameter.md
@@ -8,7 +8,7 @@
 
 > **MigrationsParameter**\<`T`\> = [`AnyVersionGreaterThan1`](AnyVersionGreaterThan1.md)\<`T`\> *extends* `true` ? `object` : `object`
 
-Defined in: ridb\_core.d.ts:489
+Defined in: ridb\_core.d.ts:423
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/MigrationsParameter.md
+++ b/docs/@trust0/ridb-core/type-aliases/MigrationsParameter.md
@@ -8,7 +8,7 @@
 
 > **MigrationsParameter**\<`T`\> = [`AnyVersionGreaterThan1`](AnyVersionGreaterThan1.md)\<`T`\> *extends* `true` ? `object` : `object`
 
-Defined in: ridb\_core.d.ts:423
+Defined in: ridb\_core.d.ts:748
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/NInOperator.md
+++ b/docs/@trust0/ridb-core/type-aliases/NInOperator.md
@@ -8,7 +8,7 @@
 
 > **NInOperator**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:265
+Defined in: ridb\_core.d.ts:404
 
 ## Type Parameters
 
@@ -22,4 +22,4 @@ Defined in: ridb\_core.d.ts:265
 
 > `optional` **$nin**: `T`[]
 
-Defined in: ridb\_core.d.ts:265
+Defined in: ridb\_core.d.ts:404

--- a/docs/@trust0/ridb-core/type-aliases/NInOperator.md
+++ b/docs/@trust0/ridb-core/type-aliases/NInOperator.md
@@ -8,7 +8,7 @@
 
 > **NInOperator**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:361
+Defined in: ridb\_core.d.ts:560
 
 ## Type Parameters
 
@@ -22,4 +22,4 @@ Defined in: ridb\_core.d.ts:361
 
 > `optional` **$nin**: `T`[]
 
-Defined in: ridb\_core.d.ts:361
+Defined in: ridb\_core.d.ts:560

--- a/docs/@trust0/ridb-core/type-aliases/NInOperator.md
+++ b/docs/@trust0/ridb-core/type-aliases/NInOperator.md
@@ -8,7 +8,7 @@
 
 > **NInOperator**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:468
+Defined in: ridb\_core.d.ts:265
 
 ## Type Parameters
 
@@ -22,4 +22,4 @@ Defined in: ridb\_core.d.ts:468
 
 > `optional` **$nin**: `T`[]
 
-Defined in: ridb\_core.d.ts:468
+Defined in: ridb\_core.d.ts:265

--- a/docs/@trust0/ridb-core/type-aliases/NInOperator.md
+++ b/docs/@trust0/ridb-core/type-aliases/NInOperator.md
@@ -8,7 +8,7 @@
 
 > **NInOperator**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:404
+Defined in: ridb\_core.d.ts:361
 
 ## Type Parameters
 
@@ -22,4 +22,4 @@ Defined in: ridb\_core.d.ts:404
 
 > `optional` **$nin**: `T`[]
 
-Defined in: ridb\_core.d.ts:404
+Defined in: ridb\_core.d.ts:361

--- a/docs/@trust0/ridb-core/type-aliases/Operation.md
+++ b/docs/@trust0/ridb-core/type-aliases/Operation.md
@@ -8,7 +8,7 @@
 
 > **Operation**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:213
+Defined in: ridb\_core.d.ts:329
 
 Represents an operation to be performed on a collection.
 
@@ -26,7 +26,7 @@ The schema type of the collection.
 
 > **collection**: `string`
 
-Defined in: ridb\_core.d.ts:217
+Defined in: ridb\_core.d.ts:333
 
 The name of the collection on which the operation will be performed.
 
@@ -36,7 +36,7 @@ The name of the collection on which the operation will be performed.
 
 > **data**: [`Doc`](Doc.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:227
+Defined in: ridb\_core.d.ts:343
 
 The data involved in the operation, conforming to the schema type.
 
@@ -46,7 +46,7 @@ The data involved in the operation, conforming to the schema type.
 
 > **opType**: [`OpType`](../enumerations/OpType.md)
 
-Defined in: ridb\_core.d.ts:222
+Defined in: ridb\_core.d.ts:338
 
 The type of operation to be performed (e.g., CREATE, UPDATE, DELETE).
 
@@ -56,7 +56,7 @@ The type of operation to be performed (e.g., CREATE, UPDATE, DELETE).
 
 > `optional` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:230
+Defined in: ridb\_core.d.ts:346
 
 ***
 
@@ -64,4 +64,4 @@ Defined in: ridb\_core.d.ts:230
 
 > `optional` **primaryKeyField**: `string`
 
-Defined in: ridb\_core.d.ts:229
+Defined in: ridb\_core.d.ts:345

--- a/docs/@trust0/ridb-core/type-aliases/Operation.md
+++ b/docs/@trust0/ridb-core/type-aliases/Operation.md
@@ -8,7 +8,7 @@
 
 > **Operation**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:329
+Defined in: ridb\_core.d.ts:655
 
 Represents an operation to be performed on a collection.
 
@@ -26,7 +26,7 @@ The schema type of the collection.
 
 > **collection**: `string`
 
-Defined in: ridb\_core.d.ts:333
+Defined in: ridb\_core.d.ts:659
 
 The name of the collection on which the operation will be performed.
 
@@ -36,7 +36,7 @@ The name of the collection on which the operation will be performed.
 
 > **data**: [`Doc`](Doc.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:343
+Defined in: ridb\_core.d.ts:669
 
 The data involved in the operation, conforming to the schema type.
 
@@ -46,7 +46,7 @@ The data involved in the operation, conforming to the schema type.
 
 > **opType**: [`OpType`](../enumerations/OpType.md)
 
-Defined in: ridb\_core.d.ts:338
+Defined in: ridb\_core.d.ts:664
 
 The type of operation to be performed (e.g., CREATE, UPDATE, DELETE).
 
@@ -56,7 +56,7 @@ The type of operation to be performed (e.g., CREATE, UPDATE, DELETE).
 
 > `optional` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:346
+Defined in: ridb\_core.d.ts:672
 
 ***
 
@@ -64,4 +64,4 @@ Defined in: ridb\_core.d.ts:346
 
 > `optional` **primaryKeyField**: `string`
 
-Defined in: ridb\_core.d.ts:345
+Defined in: ridb\_core.d.ts:671

--- a/docs/@trust0/ridb-core/type-aliases/Operation.md
+++ b/docs/@trust0/ridb-core/type-aliases/Operation.md
@@ -8,7 +8,7 @@
 
 > **Operation**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:703
+Defined in: ridb\_core.d.ts:738
 
 Represents an operation to be performed on a collection.
 
@@ -26,7 +26,7 @@ The schema type of the collection.
 
 > **collection**: `string`
 
-Defined in: ridb\_core.d.ts:707
+Defined in: ridb\_core.d.ts:742
 
 The name of the collection on which the operation will be performed.
 
@@ -36,7 +36,7 @@ The name of the collection on which the operation will be performed.
 
 > **data**: [`Doc`](Doc.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:717
+Defined in: ridb\_core.d.ts:752
 
 The data involved in the operation, conforming to the schema type.
 
@@ -46,7 +46,7 @@ The data involved in the operation, conforming to the schema type.
 
 > **opType**: [`OpType`](../enumerations/OpType.md)
 
-Defined in: ridb\_core.d.ts:712
+Defined in: ridb\_core.d.ts:747
 
 The type of operation to be performed (e.g., CREATE, UPDATE, DELETE).
 
@@ -56,7 +56,7 @@ The type of operation to be performed (e.g., CREATE, UPDATE, DELETE).
 
 > `optional` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:720
+Defined in: ridb\_core.d.ts:755
 
 ***
 
@@ -64,4 +64,4 @@ Defined in: ridb\_core.d.ts:720
 
 > `optional` **primaryKeyField**: `string`
 
-Defined in: ridb\_core.d.ts:719
+Defined in: ridb\_core.d.ts:754

--- a/docs/@trust0/ridb-core/type-aliases/Operation.md
+++ b/docs/@trust0/ridb-core/type-aliases/Operation.md
@@ -8,7 +8,7 @@
 
 > **Operation**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:738
+Defined in: ridb\_core.d.ts:213
 
 Represents an operation to be performed on a collection.
 
@@ -26,7 +26,7 @@ The schema type of the collection.
 
 > **collection**: `string`
 
-Defined in: ridb\_core.d.ts:742
+Defined in: ridb\_core.d.ts:217
 
 The name of the collection on which the operation will be performed.
 
@@ -36,7 +36,7 @@ The name of the collection on which the operation will be performed.
 
 > **data**: [`Doc`](Doc.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:752
+Defined in: ridb\_core.d.ts:227
 
 The data involved in the operation, conforming to the schema type.
 
@@ -46,7 +46,7 @@ The data involved in the operation, conforming to the schema type.
 
 > **opType**: [`OpType`](../enumerations/OpType.md)
 
-Defined in: ridb\_core.d.ts:747
+Defined in: ridb\_core.d.ts:222
 
 The type of operation to be performed (e.g., CREATE, UPDATE, DELETE).
 
@@ -56,7 +56,7 @@ The type of operation to be performed (e.g., CREATE, UPDATE, DELETE).
 
 > `optional` **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:755
+Defined in: ridb\_core.d.ts:230
 
 ***
 
@@ -64,4 +64,4 @@ Defined in: ridb\_core.d.ts:755
 
 > `optional` **primaryKeyField**: `string`
 
-Defined in: ridb\_core.d.ts:754
+Defined in: ridb\_core.d.ts:229

--- a/docs/@trust0/ridb-core/type-aliases/OperatorOrType.md
+++ b/docs/@trust0/ridb-core/type-aliases/OperatorOrType.md
@@ -8,7 +8,7 @@
 
 > **OperatorOrType**\<`T`\> = `T` *extends* `number` ? `T` \| [`Operators`](Operators.md)\<`T`\> \| [`InOperator`](InOperator.md)\<`T`\> \| [`NInOperator`](NInOperator.md)\<`T`\> : `T` \| [`InOperator`](InOperator.md)\<`T`\> \| [`NInOperator`](NInOperator.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:470
+Defined in: ridb\_core.d.ts:267
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/OperatorOrType.md
+++ b/docs/@trust0/ridb-core/type-aliases/OperatorOrType.md
@@ -8,7 +8,7 @@
 
 > **OperatorOrType**\<`T`\> = `T` *extends* `number` ? `T` \| [`Operators`](Operators.md)\<`T`\> \| [`InOperator`](InOperator.md)\<`T`\> \| [`NInOperator`](NInOperator.md)\<`T`\> : `T` \| [`InOperator`](InOperator.md)\<`T`\> \| [`NInOperator`](NInOperator.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:267
+Defined in: ridb\_core.d.ts:406
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/OperatorOrType.md
+++ b/docs/@trust0/ridb-core/type-aliases/OperatorOrType.md
@@ -8,7 +8,7 @@
 
 > **OperatorOrType**\<`T`\> = `T` *extends* `number` ? `T` \| [`Operators`](Operators.md)\<`T`\> \| [`InOperator`](InOperator.md)\<`T`\> \| [`NInOperator`](NInOperator.md)\<`T`\> : `T` \| [`InOperator`](InOperator.md)\<`T`\> \| [`NInOperator`](NInOperator.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:363
+Defined in: ridb\_core.d.ts:562
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/OperatorOrType.md
+++ b/docs/@trust0/ridb-core/type-aliases/OperatorOrType.md
@@ -8,7 +8,7 @@
 
 > **OperatorOrType**\<`T`\> = `T` *extends* `number` ? `T` \| [`Operators`](Operators.md)\<`T`\> \| [`InOperator`](InOperator.md)\<`T`\> \| [`NInOperator`](NInOperator.md)\<`T`\> : `T` \| [`InOperator`](InOperator.md)\<`T`\> \| [`NInOperator`](NInOperator.md)\<`T`\>
 
-Defined in: ridb\_core.d.ts:406
+Defined in: ridb\_core.d.ts:363
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/Operators.md
+++ b/docs/@trust0/ridb-core/type-aliases/Operators.md
@@ -8,7 +8,7 @@
 
 > **Operators**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:394
+Defined in: ridb\_core.d.ts:351
 
 ## Type Parameters
 
@@ -22,7 +22,7 @@ Defined in: ridb\_core.d.ts:394
 
 > `optional` **$eq**: `T`
 
-Defined in: ridb\_core.d.ts:399
+Defined in: ridb\_core.d.ts:356
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: ridb\_core.d.ts:399
 
 > `optional` **$gt**: `number`
 
-Defined in: ridb\_core.d.ts:396
+Defined in: ridb\_core.d.ts:353
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: ridb\_core.d.ts:396
 
 > `optional` **$gte**: `number`
 
-Defined in: ridb\_core.d.ts:395
+Defined in: ridb\_core.d.ts:352
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:395
 
 > `optional` **$lt**: `number`
 
-Defined in: ridb\_core.d.ts:397
+Defined in: ridb\_core.d.ts:354
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: ridb\_core.d.ts:397
 
 > `optional` **$lte**: `number`
 
-Defined in: ridb\_core.d.ts:398
+Defined in: ridb\_core.d.ts:355
 
 ***
 
@@ -62,4 +62,4 @@ Defined in: ridb\_core.d.ts:398
 
 > `optional` **$ne**: `T`
 
-Defined in: ridb\_core.d.ts:400
+Defined in: ridb\_core.d.ts:357

--- a/docs/@trust0/ridb-core/type-aliases/Operators.md
+++ b/docs/@trust0/ridb-core/type-aliases/Operators.md
@@ -8,7 +8,7 @@
 
 > **Operators**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:458
+Defined in: ridb\_core.d.ts:255
 
 ## Type Parameters
 
@@ -22,7 +22,7 @@ Defined in: ridb\_core.d.ts:458
 
 > `optional` **$eq**: `T`
 
-Defined in: ridb\_core.d.ts:463
+Defined in: ridb\_core.d.ts:260
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: ridb\_core.d.ts:463
 
 > `optional` **$gt**: `number`
 
-Defined in: ridb\_core.d.ts:460
+Defined in: ridb\_core.d.ts:257
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: ridb\_core.d.ts:460
 
 > `optional` **$gte**: `number`
 
-Defined in: ridb\_core.d.ts:459
+Defined in: ridb\_core.d.ts:256
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:459
 
 > `optional` **$lt**: `number`
 
-Defined in: ridb\_core.d.ts:461
+Defined in: ridb\_core.d.ts:258
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: ridb\_core.d.ts:461
 
 > `optional` **$lte**: `number`
 
-Defined in: ridb\_core.d.ts:462
+Defined in: ridb\_core.d.ts:259
 
 ***
 
@@ -62,4 +62,4 @@ Defined in: ridb\_core.d.ts:462
 
 > `optional` **$ne**: `T`
 
-Defined in: ridb\_core.d.ts:464
+Defined in: ridb\_core.d.ts:261

--- a/docs/@trust0/ridb-core/type-aliases/Operators.md
+++ b/docs/@trust0/ridb-core/type-aliases/Operators.md
@@ -8,7 +8,7 @@
 
 > **Operators**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:255
+Defined in: ridb\_core.d.ts:394
 
 ## Type Parameters
 
@@ -22,7 +22,7 @@ Defined in: ridb\_core.d.ts:255
 
 > `optional` **$eq**: `T`
 
-Defined in: ridb\_core.d.ts:260
+Defined in: ridb\_core.d.ts:399
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: ridb\_core.d.ts:260
 
 > `optional` **$gt**: `number`
 
-Defined in: ridb\_core.d.ts:257
+Defined in: ridb\_core.d.ts:396
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: ridb\_core.d.ts:257
 
 > `optional` **$gte**: `number`
 
-Defined in: ridb\_core.d.ts:256
+Defined in: ridb\_core.d.ts:395
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:256
 
 > `optional` **$lt**: `number`
 
-Defined in: ridb\_core.d.ts:258
+Defined in: ridb\_core.d.ts:397
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: ridb\_core.d.ts:258
 
 > `optional` **$lte**: `number`
 
-Defined in: ridb\_core.d.ts:259
+Defined in: ridb\_core.d.ts:398
 
 ***
 
@@ -62,4 +62,4 @@ Defined in: ridb\_core.d.ts:259
 
 > `optional` **$ne**: `T`
 
-Defined in: ridb\_core.d.ts:261
+Defined in: ridb\_core.d.ts:400

--- a/docs/@trust0/ridb-core/type-aliases/Operators.md
+++ b/docs/@trust0/ridb-core/type-aliases/Operators.md
@@ -8,7 +8,7 @@
 
 > **Operators**\<`T`\> = `object`
 
-Defined in: ridb\_core.d.ts:351
+Defined in: ridb\_core.d.ts:550
 
 ## Type Parameters
 
@@ -22,7 +22,7 @@ Defined in: ridb\_core.d.ts:351
 
 > `optional` **$eq**: `T`
 
-Defined in: ridb\_core.d.ts:356
+Defined in: ridb\_core.d.ts:555
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: ridb\_core.d.ts:356
 
 > `optional` **$gt**: `number`
 
-Defined in: ridb\_core.d.ts:353
+Defined in: ridb\_core.d.ts:552
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: ridb\_core.d.ts:353
 
 > `optional` **$gte**: `number`
 
-Defined in: ridb\_core.d.ts:352
+Defined in: ridb\_core.d.ts:551
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: ridb\_core.d.ts:352
 
 > `optional` **$lt**: `number`
 
-Defined in: ridb\_core.d.ts:354
+Defined in: ridb\_core.d.ts:553
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: ridb\_core.d.ts:354
 
 > `optional` **$lte**: `number`
 
-Defined in: ridb\_core.d.ts:355
+Defined in: ridb\_core.d.ts:554
 
 ***
 
@@ -62,4 +62,4 @@ Defined in: ridb\_core.d.ts:355
 
 > `optional` **$ne**: `T`
 
-Defined in: ridb\_core.d.ts:357
+Defined in: ridb\_core.d.ts:556

--- a/docs/@trust0/ridb-core/type-aliases/QueryOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/QueryOptions.md
@@ -8,7 +8,7 @@
 
 > **QueryOptions** = `object`
 
-Defined in: ridb\_core.d.ts:343
+Defined in: ridb\_core.d.ts:140
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: ridb\_core.d.ts:343
 
 > `optional` **limit**: `number`
 
-Defined in: ridb\_core.d.ts:344
+Defined in: ridb\_core.d.ts:141
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: ridb\_core.d.ts:344
 
 > `optional` **offset**: `number`
 
-Defined in: ridb\_core.d.ts:345
+Defined in: ridb\_core.d.ts:142

--- a/docs/@trust0/ridb-core/type-aliases/QueryOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/QueryOptions.md
@@ -8,7 +8,7 @@
 
 > **QueryOptions** = `object`
 
-Defined in: ridb\_core.d.ts:140
+Defined in: ridb\_core.d.ts:256
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: ridb\_core.d.ts:140
 
 > `optional` **limit**: `number`
 
-Defined in: ridb\_core.d.ts:141
+Defined in: ridb\_core.d.ts:257
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: ridb\_core.d.ts:141
 
 > `optional` **offset**: `number`
 
-Defined in: ridb\_core.d.ts:142
+Defined in: ridb\_core.d.ts:258

--- a/docs/@trust0/ridb-core/type-aliases/QueryOptions.md
+++ b/docs/@trust0/ridb-core/type-aliases/QueryOptions.md
@@ -8,7 +8,7 @@
 
 > **QueryOptions** = `object`
 
-Defined in: ridb\_core.d.ts:256
+Defined in: ridb\_core.d.ts:495
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: ridb\_core.d.ts:256
 
 > `optional` **limit**: `number`
 
-Defined in: ridb\_core.d.ts:257
+Defined in: ridb\_core.d.ts:496
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: ridb\_core.d.ts:257
 
 > `optional` **offset**: `number`
 
-Defined in: ridb\_core.d.ts:258
+Defined in: ridb\_core.d.ts:497

--- a/docs/@trust0/ridb-core/type-aliases/QueryType.md
+++ b/docs/@trust0/ridb-core/type-aliases/QueryType.md
@@ -8,7 +8,7 @@
 
 > **QueryType**\<`T`\> = `{ [K in keyof T["properties"] as ExtractType<T["properties"][K]["type"]> extends undefined ? never : K]?: OperatorOrType<ExtractType<T["properties"][K]["type"]>> }` & [`LogicalOperators`](LogicalOperators.md)\<`T`\> \| [`LogicalOperators`](LogicalOperators.md)\<`T`\>[]
 
-Defined in: ridb\_core.d.ts:276
+Defined in: ridb\_core.d.ts:415
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/QueryType.md
+++ b/docs/@trust0/ridb-core/type-aliases/QueryType.md
@@ -8,7 +8,7 @@
 
 > **QueryType**\<`T`\> = `{ [K in keyof T["properties"] as ExtractType<T["properties"][K]["type"]> extends undefined ? never : K]?: OperatorOrType<ExtractType<T["properties"][K]["type"]>> }` & [`LogicalOperators`](LogicalOperators.md)\<`T`\> \| [`LogicalOperators`](LogicalOperators.md)\<`T`\>[]
 
-Defined in: ridb\_core.d.ts:479
+Defined in: ridb\_core.d.ts:276
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/QueryType.md
+++ b/docs/@trust0/ridb-core/type-aliases/QueryType.md
@@ -8,7 +8,7 @@
 
 > **QueryType**\<`T`\> = `{ [K in keyof T["properties"] as ExtractType<T["properties"][K]["type"]> extends undefined ? never : K]?: OperatorOrType<ExtractType<T["properties"][K]["type"]>> }` & [`LogicalOperators`](LogicalOperators.md)\<`T`\> \| [`LogicalOperators`](LogicalOperators.md)\<`T`\>[]
 
-Defined in: ridb\_core.d.ts:415
+Defined in: ridb\_core.d.ts:372
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/QueryType.md
+++ b/docs/@trust0/ridb-core/type-aliases/QueryType.md
@@ -8,7 +8,7 @@
 
 > **QueryType**\<`T`\> = `{ [K in keyof T["properties"] as ExtractType<T["properties"][K]["type"]> extends undefined ? never : K]?: OperatorOrType<ExtractType<T["properties"][K]["type"]>> }` & [`LogicalOperators`](LogicalOperators.md)\<`T`\> \| [`LogicalOperators`](LogicalOperators.md)\<`T`\>[]
 
-Defined in: ridb\_core.d.ts:372
+Defined in: ridb\_core.d.ts:571
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-core/type-aliases/RIDBModule.md
+++ b/docs/@trust0/ridb-core/type-aliases/RIDBModule.md
@@ -8,7 +8,7 @@
 
 > **RIDBModule** = `object`
 
-Defined in: ridb\_core.d.ts:624
+Defined in: ridb\_core.d.ts:367
 
 Represents a storage module with a method for creating storage.
 
@@ -18,7 +18,7 @@ Represents a storage module with a method for creating storage.
 
 > **apply**: (`plugins`) => [`BasePlugin`](../classes/BasePlugin.md)[]
 
-Defined in: ridb\_core.d.ts:629
+Defined in: ridb\_core.d.ts:372
 
 Plugin constructors array
 

--- a/docs/@trust0/ridb-core/type-aliases/RIDBModule.md
+++ b/docs/@trust0/ridb-core/type-aliases/RIDBModule.md
@@ -8,7 +8,7 @@
 
 > **RIDBModule** = `object`
 
-Defined in: ridb\_core.d.ts:688
+Defined in: ridb\_core.d.ts:723
 
 Represents a storage module with a method for creating storage.
 
@@ -18,7 +18,7 @@ Represents a storage module with a method for creating storage.
 
 > **apply**: (`plugins`) => [`BasePlugin`](../classes/BasePlugin.md)[]
 
-Defined in: ridb\_core.d.ts:693
+Defined in: ridb\_core.d.ts:728
 
 Plugin constructors array
 

--- a/docs/@trust0/ridb-core/type-aliases/RIDBModule.md
+++ b/docs/@trust0/ridb-core/type-aliases/RIDBModule.md
@@ -8,7 +8,7 @@
 
 > **RIDBModule** = `object`
 
-Defined in: ridb\_core.d.ts:366
+Defined in: ridb\_core.d.ts:624
 
 Represents a storage module with a method for creating storage.
 
@@ -18,7 +18,7 @@ Represents a storage module with a method for creating storage.
 
 > **apply**: (`plugins`) => [`BasePlugin`](../classes/BasePlugin.md)[]
 
-Defined in: ridb\_core.d.ts:371
+Defined in: ridb\_core.d.ts:629
 
 Plugin constructors array
 

--- a/docs/@trust0/ridb-core/type-aliases/RIDBModule.md
+++ b/docs/@trust0/ridb-core/type-aliases/RIDBModule.md
@@ -8,7 +8,7 @@
 
 > **RIDBModule** = `object`
 
-Defined in: ridb\_core.d.ts:723
+Defined in: ridb\_core.d.ts:366
 
 Represents a storage module with a method for creating storage.
 
@@ -18,7 +18,7 @@ Represents a storage module with a method for creating storage.
 
 > **apply**: (`plugins`) => [`BasePlugin`](../classes/BasePlugin.md)[]
 
-Defined in: ridb\_core.d.ts:728
+Defined in: ridb\_core.d.ts:371
 
 Plugin constructors array
 

--- a/docs/@trust0/ridb-core/type-aliases/SchemaType.md
+++ b/docs/@trust0/ridb-core/type-aliases/SchemaType.md
@@ -8,7 +8,7 @@
 
 > **SchemaType** = `object`
 
-Defined in: ridb\_core.d.ts:504
+Defined in: ridb\_core.d.ts:655
 
 Represents the type definition for a schema.
 
@@ -18,7 +18,7 @@ Represents the type definition for a schema.
 
 > `optional` **encrypted**: `string`[]
 
-Defined in: ridb\_core.d.ts:520
+Defined in: ridb\_core.d.ts:671
 
 ***
 
@@ -26,7 +26,7 @@ Defined in: ridb\_core.d.ts:520
 
 > `optional` **indexes**: `string`[]
 
-Defined in: ridb\_core.d.ts:519
+Defined in: ridb\_core.d.ts:670
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: ridb\_core.d.ts:519
 
 > **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:513
+Defined in: ridb\_core.d.ts:664
 
 The primary key of the schema.
 
@@ -44,7 +44,7 @@ The primary key of the schema.
 
 > **properties**: `object`
 
-Defined in: ridb\_core.d.ts:524
+Defined in: ridb\_core.d.ts:675
 
 The properties defined in the schema.
 
@@ -58,7 +58,7 @@ The properties defined in the schema.
 
 > **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:518
+Defined in: ridb\_core.d.ts:669
 
 The type of the schema.
 
@@ -68,6 +68,6 @@ The type of the schema.
 
 > **version**: `number`
 
-Defined in: ridb\_core.d.ts:508
+Defined in: ridb\_core.d.ts:659
 
 The version of the schema.

--- a/docs/@trust0/ridb-core/type-aliases/SchemaType.md
+++ b/docs/@trust0/ridb-core/type-aliases/SchemaType.md
@@ -8,7 +8,7 @@
 
 > **SchemaType** = `object`
 
-Defined in: ridb\_core.d.ts:358
+Defined in: ridb\_core.d.ts:504
 
 Represents the type definition for a schema.
 
@@ -18,7 +18,7 @@ Represents the type definition for a schema.
 
 > `optional` **encrypted**: `string`[]
 
-Defined in: ridb\_core.d.ts:374
+Defined in: ridb\_core.d.ts:520
 
 ***
 
@@ -26,7 +26,7 @@ Defined in: ridb\_core.d.ts:374
 
 > `optional` **indexes**: `string`[]
 
-Defined in: ridb\_core.d.ts:373
+Defined in: ridb\_core.d.ts:519
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: ridb\_core.d.ts:373
 
 > **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:367
+Defined in: ridb\_core.d.ts:513
 
 The primary key of the schema.
 
@@ -44,7 +44,7 @@ The primary key of the schema.
 
 > **properties**: `object`
 
-Defined in: ridb\_core.d.ts:378
+Defined in: ridb\_core.d.ts:524
 
 The properties defined in the schema.
 
@@ -58,7 +58,7 @@ The properties defined in the schema.
 
 > **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:372
+Defined in: ridb\_core.d.ts:518
 
 The type of the schema.
 
@@ -68,6 +68,6 @@ The type of the schema.
 
 > **version**: `number`
 
-Defined in: ridb\_core.d.ts:362
+Defined in: ridb\_core.d.ts:508
 
 The version of the schema.

--- a/docs/@trust0/ridb-core/type-aliases/SchemaType.md
+++ b/docs/@trust0/ridb-core/type-aliases/SchemaType.md
@@ -8,7 +8,7 @@
 
 > **SchemaType** = `object`
 
-Defined in: ridb\_core.d.ts:79
+Defined in: ridb\_core.d.ts:358
 
 Represents the type definition for a schema.
 
@@ -18,7 +18,7 @@ Represents the type definition for a schema.
 
 > `optional` **encrypted**: `string`[]
 
-Defined in: ridb\_core.d.ts:95
+Defined in: ridb\_core.d.ts:374
 
 ***
 
@@ -26,7 +26,7 @@ Defined in: ridb\_core.d.ts:95
 
 > `optional` **indexes**: `string`[]
 
-Defined in: ridb\_core.d.ts:94
+Defined in: ridb\_core.d.ts:373
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: ridb\_core.d.ts:94
 
 > **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:88
+Defined in: ridb\_core.d.ts:367
 
 The primary key of the schema.
 
@@ -44,7 +44,7 @@ The primary key of the schema.
 
 > **properties**: `object`
 
-Defined in: ridb\_core.d.ts:99
+Defined in: ridb\_core.d.ts:378
 
 The properties defined in the schema.
 
@@ -58,7 +58,7 @@ The properties defined in the schema.
 
 > **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:93
+Defined in: ridb\_core.d.ts:372
 
 The type of the schema.
 
@@ -68,6 +68,6 @@ The type of the schema.
 
 > **version**: `number`
 
-Defined in: ridb\_core.d.ts:83
+Defined in: ridb\_core.d.ts:362
 
 The version of the schema.

--- a/docs/@trust0/ridb-core/type-aliases/SchemaType.md
+++ b/docs/@trust0/ridb-core/type-aliases/SchemaType.md
@@ -8,7 +8,7 @@
 
 > **SchemaType** = `object`
 
-Defined in: ridb\_core.d.ts:655
+Defined in: ridb\_core.d.ts:108
 
 Represents the type definition for a schema.
 
@@ -18,7 +18,7 @@ Represents the type definition for a schema.
 
 > `optional` **encrypted**: `string`[]
 
-Defined in: ridb\_core.d.ts:671
+Defined in: ridb\_core.d.ts:124
 
 ***
 
@@ -26,7 +26,7 @@ Defined in: ridb\_core.d.ts:671
 
 > `optional` **indexes**: `string`[]
 
-Defined in: ridb\_core.d.ts:670
+Defined in: ridb\_core.d.ts:123
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: ridb\_core.d.ts:670
 
 > **primaryKey**: `string`
 
-Defined in: ridb\_core.d.ts:664
+Defined in: ridb\_core.d.ts:117
 
 The primary key of the schema.
 
@@ -44,7 +44,7 @@ The primary key of the schema.
 
 > **properties**: `object`
 
-Defined in: ridb\_core.d.ts:675
+Defined in: ridb\_core.d.ts:128
 
 The properties defined in the schema.
 
@@ -58,7 +58,7 @@ The properties defined in the schema.
 
 > **type**: `SchemaFieldType`
 
-Defined in: ridb\_core.d.ts:669
+Defined in: ridb\_core.d.ts:122
 
 The type of the schema.
 
@@ -68,6 +68,6 @@ The type of the schema.
 
 > **version**: `number`
 
-Defined in: ridb\_core.d.ts:659
+Defined in: ridb\_core.d.ts:112
 
 The version of the schema.

--- a/docs/@trust0/ridb-core/type-aliases/SchemaTypeRecord.md
+++ b/docs/@trust0/ridb-core/type-aliases/SchemaTypeRecord.md
@@ -8,7 +8,7 @@
 
 > **SchemaTypeRecord** = `object`
 
-Defined in: ridb\_core.d.ts:585
+Defined in: ridb\_core.d.ts:677
 
 **`Internal`**
 

--- a/docs/@trust0/ridb-core/type-aliases/SchemaTypeRecord.md
+++ b/docs/@trust0/ridb-core/type-aliases/SchemaTypeRecord.md
@@ -8,7 +8,7 @@
 
 > **SchemaTypeRecord** = `object`
 
-Defined in: ridb\_core.d.ts:462
+Defined in: ridb\_core.d.ts:681
 
 **`Internal`**
 

--- a/docs/@trust0/ridb-core/type-aliases/SchemaTypeRecord.md
+++ b/docs/@trust0/ridb-core/type-aliases/SchemaTypeRecord.md
@@ -8,7 +8,7 @@
 
 > **SchemaTypeRecord** = `object`
 
-Defined in: ridb\_core.d.ts:677
+Defined in: ridb\_core.d.ts:462
 
 **`Internal`**
 

--- a/docs/@trust0/ridb-core/type-aliases/SchemaTypeRecord.md
+++ b/docs/@trust0/ridb-core/type-aliases/SchemaTypeRecord.md
@@ -8,7 +8,7 @@
 
 > **SchemaTypeRecord** = `object`
 
-Defined in: ridb\_core.d.ts:729
+Defined in: ridb\_core.d.ts:585
 
 **`Internal`**
 

--- a/docs/@trust0/ridb-core/type-aliases/SyncInitInput.md
+++ b/docs/@trust0/ridb-core/type-aliases/SyncInitInput.md
@@ -8,4 +8,4 @@
 
 > **SyncInitInput** = `BufferSource` \| `WebAssembly.Module`
 
-Defined in: ridb\_core.d.ts:1032
+Defined in: ridb\_core.d.ts:1033

--- a/docs/@trust0/ridb-core/type-aliases/SyncInitInput.md
+++ b/docs/@trust0/ridb-core/type-aliases/SyncInitInput.md
@@ -8,4 +8,4 @@
 
 > **SyncInitInput** = `BufferSource` \| `WebAssembly.Module`
 
-Defined in: ridb\_core.d.ts:1033
+Defined in: ridb\_core.d.ts:1034

--- a/docs/@trust0/ridb-core/variables/SchemaFieldType.md
+++ b/docs/@trust0/ridb-core/variables/SchemaFieldType.md
@@ -8,7 +8,7 @@
 
 > `const` **SchemaFieldType**: `object`
 
-Defined in: ridb\_core.d.ts:140
+Defined in: ridb\_core.d.ts:76
 
 ## Type declaration
 

--- a/docs/@trust0/ridb-core/variables/SchemaFieldType.md
+++ b/docs/@trust0/ridb-core/variables/SchemaFieldType.md
@@ -8,7 +8,7 @@
 
 > `const` **SchemaFieldType**: `object`
 
-Defined in: ridb\_core.d.ts:708
+Defined in: ridb\_core.d.ts:140
 
 ## Type declaration
 

--- a/docs/@trust0/ridb-core/variables/SchemaFieldType.md
+++ b/docs/@trust0/ridb-core/variables/SchemaFieldType.md
@@ -8,7 +8,7 @@
 
 > `const` **SchemaFieldType**: `object`
 
-Defined in: ridb\_core.d.ts:250
+Defined in: ridb\_core.d.ts:529
 
 ## Type declaration
 

--- a/docs/@trust0/ridb-core/variables/SchemaFieldType.md
+++ b/docs/@trust0/ridb-core/variables/SchemaFieldType.md
@@ -8,7 +8,7 @@
 
 > `const` **SchemaFieldType**: `object`
 
-Defined in: ridb\_core.d.ts:529
+Defined in: ridb\_core.d.ts:708
 
 ## Type declaration
 

--- a/docs/@trust0/ridb-level/functions/createLevelDB.md
+++ b/docs/@trust0/ridb-level/functions/createLevelDB.md
@@ -8,7 +8,7 @@
 
 > **createLevelDB**\<`T`\>(): `Promise`\<*typeof* [`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\>
 
-Defined in: [index.ts:37](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-level/src/index.ts#L37)
+Defined in: [index.ts:37](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-level/src/index.ts#L37)
 
 Create a LevelDB storage instance
 

--- a/docs/@trust0/ridb-level/functions/createLevelDB.md
+++ b/docs/@trust0/ridb-level/functions/createLevelDB.md
@@ -8,7 +8,7 @@
 
 > **createLevelDB**\<`T`\>(): `Promise`\<*typeof* [`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\>
 
-Defined in: [index.ts:37](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-level/src/index.ts#L37)
+Defined in: [index.ts:37](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-level/src/index.ts#L37)
 
 Create a LevelDB storage instance
 

--- a/docs/@trust0/ridb-level/functions/createLevelDB.md
+++ b/docs/@trust0/ridb-level/functions/createLevelDB.md
@@ -8,7 +8,7 @@
 
 > **createLevelDB**\<`T`\>(): `Promise`\<*typeof* [`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\>
 
-Defined in: [index.ts:37](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-level/src/index.ts#L37)
+Defined in: [index.ts:37](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-level/src/index.ts#L37)
 
 Create a LevelDB storage instance
 

--- a/docs/@trust0/ridb-level/functions/createLevelDB.md
+++ b/docs/@trust0/ridb-level/functions/createLevelDB.md
@@ -8,7 +8,7 @@
 
 > **createLevelDB**\<`T`\>(): `Promise`\<*typeof* [`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\>
 
-Defined in: [index.ts:37](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-level/src/index.ts#L37)
+Defined in: [index.ts:37](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-level/src/index.ts#L37)
 
 Create a LevelDB storage instance
 

--- a/docs/@trust0/ridb-level/functions/createLevelDB.md
+++ b/docs/@trust0/ridb-level/functions/createLevelDB.md
@@ -8,7 +8,7 @@
 
 > **createLevelDB**\<`T`\>(): `Promise`\<*typeof* [`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\>
 
-Defined in: [index.ts:37](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-level/src/index.ts#L37)
+Defined in: [index.ts:37](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-level/src/index.ts#L37)
 
 Create a LevelDB storage instance
 

--- a/docs/@trust0/ridb-level/type-aliases/Level.md
+++ b/docs/@trust0/ridb-level/type-aliases/Level.md
@@ -8,4 +8,4 @@
 
 > **Level** = `ClassicLevel`\<`string`, `string`\>
 
-Defined in: [index.ts:30](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-level/src/index.ts#L30)
+Defined in: [index.ts:30](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-level/src/index.ts#L30)

--- a/docs/@trust0/ridb-level/type-aliases/Level.md
+++ b/docs/@trust0/ridb-level/type-aliases/Level.md
@@ -8,4 +8,4 @@
 
 > **Level** = `ClassicLevel`\<`string`, `string`\>
 
-Defined in: [index.ts:30](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-level/src/index.ts#L30)
+Defined in: [index.ts:30](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-level/src/index.ts#L30)

--- a/docs/@trust0/ridb-level/type-aliases/Level.md
+++ b/docs/@trust0/ridb-level/type-aliases/Level.md
@@ -8,4 +8,4 @@
 
 > **Level** = `ClassicLevel`\<`string`, `string`\>
 
-Defined in: [index.ts:30](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-level/src/index.ts#L30)
+Defined in: [index.ts:30](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-level/src/index.ts#L30)

--- a/docs/@trust0/ridb-level/type-aliases/Level.md
+++ b/docs/@trust0/ridb-level/type-aliases/Level.md
@@ -8,4 +8,4 @@
 
 > **Level** = `ClassicLevel`\<`string`, `string`\>
 
-Defined in: [index.ts:30](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-level/src/index.ts#L30)
+Defined in: [index.ts:30](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-level/src/index.ts#L30)

--- a/docs/@trust0/ridb-level/type-aliases/Level.md
+++ b/docs/@trust0/ridb-level/type-aliases/Level.md
@@ -8,4 +8,4 @@
 
 > **Level** = `ClassicLevel`\<`string`, `string`\>
 
-Defined in: [index.ts:30](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-level/src/index.ts#L30)
+Defined in: [index.ts:30](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-level/src/index.ts#L30)

--- a/docs/@trust0/ridb-mongodb/functions/createMongoDB.md
+++ b/docs/@trust0/ridb-mongodb/functions/createMongoDB.md
@@ -8,7 +8,7 @@
 
 > **createMongoDB**\<`T`\>(): `Promise`\<*typeof* [`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\>
 
-Defined in: [index.ts:55](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L55)
+Defined in: [index.ts:55](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-mongodb/src/index.ts#L55)
 
 Create a MongoDB storage instance
 

--- a/docs/@trust0/ridb-mongodb/functions/createMongoDB.md
+++ b/docs/@trust0/ridb-mongodb/functions/createMongoDB.md
@@ -8,7 +8,7 @@
 
 > **createMongoDB**\<`T`\>(): `Promise`\<*typeof* [`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\>
 
-Defined in: [index.ts:55](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L55)
+Defined in: [index.ts:55](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L55)
 
 Create a MongoDB storage instance
 

--- a/docs/@trust0/ridb-mongodb/functions/createMongoDB.md
+++ b/docs/@trust0/ridb-mongodb/functions/createMongoDB.md
@@ -8,7 +8,7 @@
 
 > **createMongoDB**\<`T`\>(): `Promise`\<*typeof* [`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\>
 
-Defined in: [index.ts:55](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-mongodb/src/index.ts#L55)
+Defined in: [index.ts:55](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L55)
 
 Create a MongoDB storage instance
 

--- a/docs/@trust0/ridb-mongodb/functions/createMongoDB.md
+++ b/docs/@trust0/ridb-mongodb/functions/createMongoDB.md
@@ -8,7 +8,7 @@
 
 > **createMongoDB**\<`T`\>(): `Promise`\<*typeof* [`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\>
 
-Defined in: [index.ts:55](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L55)
+Defined in: [index.ts:55](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L55)
 
 Create a MongoDB storage instance
 

--- a/docs/@trust0/ridb-mongodb/functions/createMongoDB.md
+++ b/docs/@trust0/ridb-mongodb/functions/createMongoDB.md
@@ -8,7 +8,7 @@
 
 > **createMongoDB**\<`T`\>(): `Promise`\<*typeof* [`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\>
 
-Defined in: [index.ts:55](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L55)
+Defined in: [index.ts:55](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L55)
 
 Create a MongoDB storage instance
 

--- a/docs/@trust0/ridb-mongodb/interfaces/MongoDBConfig.md
+++ b/docs/@trust0/ridb-mongodb/interfaces/MongoDBConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: MongoDBConfig
 
-Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L39)
+Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L39)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/03ec8397ac
 
 > `optional` **dbName**: `string`
 
-Defined in: [index.ts:43](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L43)
+Defined in: [index.ts:43](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L43)
 
 Database name in MongoDB
 
@@ -24,7 +24,7 @@ Database name in MongoDB
 
 > `optional` **mongoOptions**: `Record`\<`string`, `any`\>
 
-Defined in: [index.ts:45](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L45)
+Defined in: [index.ts:45](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L45)
 
 MongoDB client options
 
@@ -34,6 +34,6 @@ MongoDB client options
 
 > `optional` **url**: `string`
 
-Defined in: [index.ts:41](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L41)
+Defined in: [index.ts:41](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L41)
 
 MongoDB connection URL

--- a/docs/@trust0/ridb-mongodb/interfaces/MongoDBConfig.md
+++ b/docs/@trust0/ridb-mongodb/interfaces/MongoDBConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: MongoDBConfig
 
-Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L39)
+Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-mongodb/src/index.ts#L39)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/9786676f41
 
 > `optional` **dbName**: `string`
 
-Defined in: [index.ts:43](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L43)
+Defined in: [index.ts:43](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-mongodb/src/index.ts#L43)
 
 Database name in MongoDB
 
@@ -24,7 +24,7 @@ Database name in MongoDB
 
 > `optional` **mongoOptions**: `Record`\<`string`, `any`\>
 
-Defined in: [index.ts:45](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L45)
+Defined in: [index.ts:45](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-mongodb/src/index.ts#L45)
 
 MongoDB client options
 
@@ -34,6 +34,6 @@ MongoDB client options
 
 > `optional` **url**: `string`
 
-Defined in: [index.ts:41](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L41)
+Defined in: [index.ts:41](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-mongodb/src/index.ts#L41)
 
 MongoDB connection URL

--- a/docs/@trust0/ridb-mongodb/interfaces/MongoDBConfig.md
+++ b/docs/@trust0/ridb-mongodb/interfaces/MongoDBConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: MongoDBConfig
 
-Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-mongodb/src/index.ts#L39)
+Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L39)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/766b641e98
 
 > `optional` **dbName**: `string`
 
-Defined in: [index.ts:43](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-mongodb/src/index.ts#L43)
+Defined in: [index.ts:43](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L43)
 
 Database name in MongoDB
 
@@ -24,7 +24,7 @@ Database name in MongoDB
 
 > `optional` **mongoOptions**: `Record`\<`string`, `any`\>
 
-Defined in: [index.ts:45](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-mongodb/src/index.ts#L45)
+Defined in: [index.ts:45](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L45)
 
 MongoDB client options
 
@@ -34,6 +34,6 @@ MongoDB client options
 
 > `optional` **url**: `string`
 
-Defined in: [index.ts:41](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-mongodb/src/index.ts#L41)
+Defined in: [index.ts:41](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L41)
 
 MongoDB connection URL

--- a/docs/@trust0/ridb-mongodb/interfaces/MongoDBConfig.md
+++ b/docs/@trust0/ridb-mongodb/interfaces/MongoDBConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: MongoDBConfig
 
-Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L39)
+Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L39)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/1178ca486d
 
 > `optional` **dbName**: `string`
 
-Defined in: [index.ts:43](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L43)
+Defined in: [index.ts:43](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L43)
 
 Database name in MongoDB
 
@@ -24,7 +24,7 @@ Database name in MongoDB
 
 > `optional` **mongoOptions**: `Record`\<`string`, `any`\>
 
-Defined in: [index.ts:45](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L45)
+Defined in: [index.ts:45](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L45)
 
 MongoDB client options
 
@@ -34,6 +34,6 @@ MongoDB client options
 
 > `optional` **url**: `string`
 
-Defined in: [index.ts:41](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L41)
+Defined in: [index.ts:41](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L41)
 
 MongoDB connection URL

--- a/docs/@trust0/ridb-mongodb/interfaces/MongoDBConfig.md
+++ b/docs/@trust0/ridb-mongodb/interfaces/MongoDBConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: MongoDBConfig
 
-Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L39)
+Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L39)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [index.ts:39](https://github.com/trust0-project/RIDB/blob/91e7813a35
 
 > `optional` **dbName**: `string`
 
-Defined in: [index.ts:43](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L43)
+Defined in: [index.ts:43](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L43)
 
 Database name in MongoDB
 
@@ -24,7 +24,7 @@ Database name in MongoDB
 
 > `optional` **mongoOptions**: `Record`\<`string`, `any`\>
 
-Defined in: [index.ts:45](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L45)
+Defined in: [index.ts:45](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L45)
 
 MongoDB client options
 
@@ -34,6 +34,6 @@ MongoDB client options
 
 > `optional` **url**: `string`
 
-Defined in: [index.ts:41](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L41)
+Defined in: [index.ts:41](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L41)
 
 MongoDB connection URL

--- a/docs/@trust0/ridb-mongodb/type-aliases/MongoDBStorageOptions.md
+++ b/docs/@trust0/ridb-mongodb/type-aliases/MongoDBStorageOptions.md
@@ -8,4 +8,4 @@
 
 > **MongoDBStorageOptions** = `BaseStorageOptions` & [`MongoDBConfig`](../interfaces/MongoDBConfig.md)
 
-Defined in: [index.ts:48](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L48)
+Defined in: [index.ts:48](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L48)

--- a/docs/@trust0/ridb-mongodb/type-aliases/MongoDBStorageOptions.md
+++ b/docs/@trust0/ridb-mongodb/type-aliases/MongoDBStorageOptions.md
@@ -8,4 +8,4 @@
 
 > **MongoDBStorageOptions** = `BaseStorageOptions` & [`MongoDBConfig`](../interfaces/MongoDBConfig.md)
 
-Defined in: [index.ts:48](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L48)
+Defined in: [index.ts:48](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-mongodb/src/index.ts#L48)

--- a/docs/@trust0/ridb-mongodb/type-aliases/MongoDBStorageOptions.md
+++ b/docs/@trust0/ridb-mongodb/type-aliases/MongoDBStorageOptions.md
@@ -8,4 +8,4 @@
 
 > **MongoDBStorageOptions** = `BaseStorageOptions` & [`MongoDBConfig`](../interfaces/MongoDBConfig.md)
 
-Defined in: [index.ts:48](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-mongodb/src/index.ts#L48)
+Defined in: [index.ts:48](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-mongodb/src/index.ts#L48)

--- a/docs/@trust0/ridb-mongodb/type-aliases/MongoDBStorageOptions.md
+++ b/docs/@trust0/ridb-mongodb/type-aliases/MongoDBStorageOptions.md
@@ -8,4 +8,4 @@
 
 > **MongoDBStorageOptions** = `BaseStorageOptions` & [`MongoDBConfig`](../interfaces/MongoDBConfig.md)
 
-Defined in: [index.ts:48](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-mongodb/src/index.ts#L48)
+Defined in: [index.ts:48](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L48)

--- a/docs/@trust0/ridb-mongodb/type-aliases/MongoDBStorageOptions.md
+++ b/docs/@trust0/ridb-mongodb/type-aliases/MongoDBStorageOptions.md
@@ -8,4 +8,4 @@
 
 > **MongoDBStorageOptions** = `BaseStorageOptions` & [`MongoDBConfig`](../interfaces/MongoDBConfig.md)
 
-Defined in: [index.ts:48](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-mongodb/src/index.ts#L48)
+Defined in: [index.ts:48](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-mongodb/src/index.ts#L48)

--- a/docs/@trust0/ridb-react/functions/RIDBDatabase.md
+++ b/docs/@trust0/ridb-react/functions/RIDBDatabase.md
@@ -8,7 +8,7 @@
 
 > **RIDBDatabase**\<`T`\>(`__namedParameters`): `Element`
 
-Defined in: [index.tsx:26](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-react/src/index.tsx#L26)
+Defined in: [index.tsx:26](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-react/src/index.tsx#L26)
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-react/functions/RIDBDatabase.md
+++ b/docs/@trust0/ridb-react/functions/RIDBDatabase.md
@@ -8,7 +8,7 @@
 
 > **RIDBDatabase**\<`T`\>(`__namedParameters`): `Element`
 
-Defined in: [index.tsx:26](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-react/src/index.tsx#L26)
+Defined in: [index.tsx:26](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-react/src/index.tsx#L26)
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-react/functions/RIDBDatabase.md
+++ b/docs/@trust0/ridb-react/functions/RIDBDatabase.md
@@ -8,7 +8,7 @@
 
 > **RIDBDatabase**\<`T`\>(`__namedParameters`): `Element`
 
-Defined in: [index.tsx:26](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-react/src/index.tsx#L26)
+Defined in: [index.tsx:26](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-react/src/index.tsx#L26)
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-react/functions/RIDBDatabase.md
+++ b/docs/@trust0/ridb-react/functions/RIDBDatabase.md
@@ -8,7 +8,7 @@
 
 > **RIDBDatabase**\<`T`\>(`__namedParameters`): `Element`
 
-Defined in: [index.tsx:26](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-react/src/index.tsx#L26)
+Defined in: [index.tsx:26](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-react/src/index.tsx#L26)
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-react/functions/RIDBDatabase.md
+++ b/docs/@trust0/ridb-react/functions/RIDBDatabase.md
@@ -8,7 +8,7 @@
 
 > **RIDBDatabase**\<`T`\>(`__namedParameters`): `Element`
 
-Defined in: [index.tsx:26](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-react/src/index.tsx#L26)
+Defined in: [index.tsx:26](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-react/src/index.tsx#L26)
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-react/functions/useRIDB.md
+++ b/docs/@trust0/ridb-react/functions/useRIDB.md
@@ -8,7 +8,7 @@
 
 > **useRIDB**\<`T`\>(): `object`
 
-Defined in: [index.tsx:18](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-react/src/index.tsx#L18)
+Defined in: [index.tsx:18](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-react/src/index.tsx#L18)
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-react/functions/useRIDB.md
+++ b/docs/@trust0/ridb-react/functions/useRIDB.md
@@ -8,7 +8,7 @@
 
 > **useRIDB**\<`T`\>(): `object`
 
-Defined in: [index.tsx:18](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-react/src/index.tsx#L18)
+Defined in: [index.tsx:18](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-react/src/index.tsx#L18)
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-react/functions/useRIDB.md
+++ b/docs/@trust0/ridb-react/functions/useRIDB.md
@@ -8,7 +8,7 @@
 
 > **useRIDB**\<`T`\>(): `object`
 
-Defined in: [index.tsx:18](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-react/src/index.tsx#L18)
+Defined in: [index.tsx:18](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-react/src/index.tsx#L18)
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-react/functions/useRIDB.md
+++ b/docs/@trust0/ridb-react/functions/useRIDB.md
@@ -8,7 +8,7 @@
 
 > **useRIDB**\<`T`\>(): `object`
 
-Defined in: [index.tsx:18](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-react/src/index.tsx#L18)
+Defined in: [index.tsx:18](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-react/src/index.tsx#L18)
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-react/functions/useRIDB.md
+++ b/docs/@trust0/ridb-react/functions/useRIDB.md
@@ -8,7 +8,7 @@
 
 > **useRIDB**\<`T`\>(): `object`
 
-Defined in: [index.tsx:18](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-react/src/index.tsx#L18)
+Defined in: [index.tsx:18](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-react/src/index.tsx#L18)
 
 ## Type Parameters
 

--- a/docs/@trust0/ridb-react/type-aliases/DatabaseState.md
+++ b/docs/@trust0/ridb-react/type-aliases/DatabaseState.md
@@ -8,4 +8,4 @@
 
 > **DatabaseState** = `"disconnected"` \| `"loading"` \| `"loaded"` \| `"error"`
 
-Defined in: [index.tsx:6](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-react/src/index.tsx#L6)
+Defined in: [index.tsx:6](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-react/src/index.tsx#L6)

--- a/docs/@trust0/ridb-react/type-aliases/DatabaseState.md
+++ b/docs/@trust0/ridb-react/type-aliases/DatabaseState.md
@@ -8,4 +8,4 @@
 
 > **DatabaseState** = `"disconnected"` \| `"loading"` \| `"loaded"` \| `"error"`
 
-Defined in: [index.tsx:6](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-react/src/index.tsx#L6)
+Defined in: [index.tsx:6](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-react/src/index.tsx#L6)

--- a/docs/@trust0/ridb-react/type-aliases/DatabaseState.md
+++ b/docs/@trust0/ridb-react/type-aliases/DatabaseState.md
@@ -8,4 +8,4 @@
 
 > **DatabaseState** = `"disconnected"` \| `"loading"` \| `"loaded"` \| `"error"`
 
-Defined in: [index.tsx:6](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-react/src/index.tsx#L6)
+Defined in: [index.tsx:6](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-react/src/index.tsx#L6)

--- a/docs/@trust0/ridb-react/type-aliases/DatabaseState.md
+++ b/docs/@trust0/ridb-react/type-aliases/DatabaseState.md
@@ -8,4 +8,4 @@
 
 > **DatabaseState** = `"disconnected"` \| `"loading"` \| `"loaded"` \| `"error"`
 
-Defined in: [index.tsx:6](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-react/src/index.tsx#L6)
+Defined in: [index.tsx:6](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-react/src/index.tsx#L6)

--- a/docs/@trust0/ridb-react/type-aliases/DatabaseState.md
+++ b/docs/@trust0/ridb-react/type-aliases/DatabaseState.md
@@ -8,4 +8,4 @@
 
 > **DatabaseState** = `"disconnected"` \| `"loading"` \| `"loaded"` \| `"error"`
 
-Defined in: [index.tsx:6](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-react/src/index.tsx#L6)
+Defined in: [index.tsx:6](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-react/src/index.tsx#L6)

--- a/docs/@trust0/ridb-react/variables/RIDBContext.md
+++ b/docs/@trust0/ridb-react/variables/RIDBContext.md
@@ -8,4 +8,4 @@
 
 > `const` **RIDBContext**: `Context`\<`Context`\<`any`\>\>
 
-Defined in: [index.tsx:16](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-react/src/index.tsx#L16)
+Defined in: [index.tsx:16](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-react/src/index.tsx#L16)

--- a/docs/@trust0/ridb-react/variables/RIDBContext.md
+++ b/docs/@trust0/ridb-react/variables/RIDBContext.md
@@ -8,4 +8,4 @@
 
 > `const` **RIDBContext**: `Context`\<`Context`\<`any`\>\>
 
-Defined in: [index.tsx:16](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb-react/src/index.tsx#L16)
+Defined in: [index.tsx:16](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb-react/src/index.tsx#L16)

--- a/docs/@trust0/ridb-react/variables/RIDBContext.md
+++ b/docs/@trust0/ridb-react/variables/RIDBContext.md
@@ -8,4 +8,4 @@
 
 > `const` **RIDBContext**: `Context`\<`Context`\<`any`\>\>
 
-Defined in: [index.tsx:16](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb-react/src/index.tsx#L16)
+Defined in: [index.tsx:16](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-react/src/index.tsx#L16)

--- a/docs/@trust0/ridb-react/variables/RIDBContext.md
+++ b/docs/@trust0/ridb-react/variables/RIDBContext.md
@@ -8,4 +8,4 @@
 
 > `const` **RIDBContext**: `Context`\<`Context`\<`any`\>\>
 
-Defined in: [index.tsx:16](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb-react/src/index.tsx#L16)
+Defined in: [index.tsx:16](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-react/src/index.tsx#L16)

--- a/docs/@trust0/ridb-react/variables/RIDBContext.md
+++ b/docs/@trust0/ridb-react/variables/RIDBContext.md
@@ -8,4 +8,4 @@
 
 > `const` **RIDBContext**: `Context`\<`Context`\<`any`\>\>
 
-Defined in: [index.tsx:16](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb-react/src/index.tsx#L16)
+Defined in: [index.tsx:16](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb-react/src/index.tsx#L16)

--- a/docs/@trust0/ridb/classes/RIDB.md
+++ b/docs/@trust0/ridb/classes/RIDB.md
@@ -6,7 +6,7 @@
 
 # Class: RIDB\<T\>
 
-Defined in: [index.ts:155](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L155)
+Defined in: [index.ts:155](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/index.ts#L155)
 
 Main RIDB class that provides database functionality with optional worker support.
 
@@ -27,7 +27,7 @@ Schema type record defining the database schema structure
 
 > **new RIDB**\<`T`\>(`options`): `RIDB`\<`T`\>
 
-Defined in: [index.ts:179](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L179)
+Defined in: [index.ts:179](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/index.ts#L179)
 
 Creates a new RIDB instance.
 
@@ -69,7 +69,7 @@ const db = new RIDB({
 
 > **get** **collections**(): \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: [index.ts:196](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L196)
+Defined in: [index.ts:196](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/index.ts#L196)
 
 Access the database collections.
 
@@ -97,7 +97,7 @@ An object containing all collections defined in the schema
 
 > **get** **started**(): `boolean`
 
-Defined in: [index.ts:253](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L253)
+Defined in: [index.ts:253](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/index.ts#L253)
 
 Checks if the database has been successfully started.
 
@@ -125,7 +125,7 @@ True if the database is started, false otherwise
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: [index.ts:234](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L234)
+Defined in: [index.ts:234](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/index.ts#L234)
 
 Closes the database connection and releases resources.
 
@@ -148,7 +148,7 @@ await db.close();
 
 > **start**(`options?`): `Promise`\<`void`\>
 
-Defined in: [index.ts:220](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L220)
+Defined in: [index.ts:220](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/index.ts#L220)
 
 Starts the database and initializes all collections.
 

--- a/docs/@trust0/ridb/classes/RIDB.md
+++ b/docs/@trust0/ridb/classes/RIDB.md
@@ -6,7 +6,7 @@
 
 # Class: RIDB\<T\>
 
-Defined in: [index.ts:155](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/index.ts#L155)
+Defined in: [index.ts:155](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L155)
 
 Main RIDB class that provides database functionality with optional worker support.
 
@@ -27,7 +27,7 @@ Schema type record defining the database schema structure
 
 > **new RIDB**\<`T`\>(`options`): `RIDB`\<`T`\>
 
-Defined in: [index.ts:179](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/index.ts#L179)
+Defined in: [index.ts:179](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L179)
 
 Creates a new RIDB instance.
 
@@ -69,7 +69,7 @@ const db = new RIDB({
 
 > **get** **collections**(): \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: [index.ts:196](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/index.ts#L196)
+Defined in: [index.ts:196](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L196)
 
 Access the database collections.
 
@@ -97,7 +97,7 @@ An object containing all collections defined in the schema
 
 > **get** **started**(): `boolean`
 
-Defined in: [index.ts:253](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/index.ts#L253)
+Defined in: [index.ts:253](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L253)
 
 Checks if the database has been successfully started.
 
@@ -125,7 +125,7 @@ True if the database is started, false otherwise
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: [index.ts:234](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/index.ts#L234)
+Defined in: [index.ts:234](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L234)
 
 Closes the database connection and releases resources.
 
@@ -148,7 +148,7 @@ await db.close();
 
 > **start**(`options?`): `Promise`\<`void`\>
 
-Defined in: [index.ts:220](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/index.ts#L220)
+Defined in: [index.ts:220](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L220)
 
 Starts the database and initializes all collections.
 

--- a/docs/@trust0/ridb/classes/RIDB.md
+++ b/docs/@trust0/ridb/classes/RIDB.md
@@ -6,7 +6,7 @@
 
 # Class: RIDB\<T\>
 
-Defined in: [index.ts:155](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L155)
+Defined in: [index.ts:155](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L155)
 
 Main RIDB class that provides database functionality with optional worker support.
 
@@ -27,7 +27,7 @@ Schema type record defining the database schema structure
 
 > **new RIDB**\<`T`\>(`options`): `RIDB`\<`T`\>
 
-Defined in: [index.ts:179](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L179)
+Defined in: [index.ts:179](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L179)
 
 Creates a new RIDB instance.
 
@@ -69,7 +69,7 @@ const db = new RIDB({
 
 > **get** **collections**(): \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: [index.ts:196](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L196)
+Defined in: [index.ts:196](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L196)
 
 Access the database collections.
 
@@ -97,7 +97,7 @@ An object containing all collections defined in the schema
 
 > **get** **started**(): `boolean`
 
-Defined in: [index.ts:253](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L253)
+Defined in: [index.ts:253](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L253)
 
 Checks if the database has been successfully started.
 
@@ -125,7 +125,7 @@ True if the database is started, false otherwise
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: [index.ts:234](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L234)
+Defined in: [index.ts:234](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L234)
 
 Closes the database connection and releases resources.
 
@@ -148,7 +148,7 @@ await db.close();
 
 > **start**(`options?`): `Promise`\<`void`\>
 
-Defined in: [index.ts:220](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L220)
+Defined in: [index.ts:220](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/index.ts#L220)
 
 Starts the database and initializes all collections.
 

--- a/docs/@trust0/ridb/classes/RIDB.md
+++ b/docs/@trust0/ridb/classes/RIDB.md
@@ -6,7 +6,7 @@
 
 # Class: RIDB\<T\>
 
-Defined in: [index.ts:155](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L155)
+Defined in: [index.ts:155](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L155)
 
 Main RIDB class that provides database functionality with optional worker support.
 
@@ -27,7 +27,7 @@ Schema type record defining the database schema structure
 
 > **new RIDB**\<`T`\>(`options`): `RIDB`\<`T`\>
 
-Defined in: [index.ts:179](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L179)
+Defined in: [index.ts:179](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L179)
 
 Creates a new RIDB instance.
 
@@ -69,7 +69,7 @@ const db = new RIDB({
 
 > **get** **collections**(): \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: [index.ts:196](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L196)
+Defined in: [index.ts:196](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L196)
 
 Access the database collections.
 
@@ -97,7 +97,7 @@ An object containing all collections defined in the schema
 
 > **get** **started**(): `boolean`
 
-Defined in: [index.ts:253](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L253)
+Defined in: [index.ts:253](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L253)
 
 Checks if the database has been successfully started.
 
@@ -125,7 +125,7 @@ True if the database is started, false otherwise
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: [index.ts:234](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L234)
+Defined in: [index.ts:234](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L234)
 
 Closes the database connection and releases resources.
 
@@ -148,7 +148,7 @@ await db.close();
 
 > **start**(`options?`): `Promise`\<`void`\>
 
-Defined in: [index.ts:220](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L220)
+Defined in: [index.ts:220](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/index.ts#L220)
 
 Starts the database and initializes all collections.
 

--- a/docs/@trust0/ridb/classes/RIDB.md
+++ b/docs/@trust0/ridb/classes/RIDB.md
@@ -6,7 +6,7 @@
 
 # Class: RIDB\<T\>
 
-Defined in: [index.ts:155](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L155)
+Defined in: [index.ts:155](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L155)
 
 Main RIDB class that provides database functionality with optional worker support.
 
@@ -27,7 +27,7 @@ Schema type record defining the database schema structure
 
 > **new RIDB**\<`T`\>(`options`): `RIDB`\<`T`\>
 
-Defined in: [index.ts:179](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L179)
+Defined in: [index.ts:179](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L179)
 
 Creates a new RIDB instance.
 
@@ -69,7 +69,7 @@ const db = new RIDB({
 
 > **get** **collections**(): \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: [index.ts:196](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L196)
+Defined in: [index.ts:196](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L196)
 
 Access the database collections.
 
@@ -97,7 +97,7 @@ An object containing all collections defined in the schema
 
 > **get** **started**(): `boolean`
 
-Defined in: [index.ts:253](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L253)
+Defined in: [index.ts:253](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L253)
 
 Checks if the database has been successfully started.
 
@@ -125,7 +125,7 @@ True if the database is started, false otherwise
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: [index.ts:234](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L234)
+Defined in: [index.ts:234](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L234)
 
 Closes the database connection and releases resources.
 
@@ -148,7 +148,7 @@ await db.close();
 
 > **start**(`options?`): `Promise`\<`void`\>
 
-Defined in: [index.ts:220](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/index.ts#L220)
+Defined in: [index.ts:220](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/index.ts#L220)
 
 Starts the database and initializes all collections.
 

--- a/docs/@trust0/ridb/enumerations/StorageType.md
+++ b/docs/@trust0/ridb/enumerations/StorageType.md
@@ -6,7 +6,7 @@
 
 # Enumeration: StorageType
 
-Defined in: [types.ts:24](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L24)
+Defined in: [types.ts:24](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L24)
 
 Enumeration of built-in storage types supported by RIDB.
 
@@ -16,7 +16,7 @@ Enumeration of built-in storage types supported by RIDB.
 
 > **IndexDB**: `"IndexDB"`
 
-Defined in: [types.ts:33](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L33)
+Defined in: [types.ts:33](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L33)
 
 IndexedDB-based storage for persistent data in the browser
 
@@ -26,6 +26,6 @@ IndexedDB-based storage for persistent data in the browser
 
 > **InMemory**: `"InMemory"`
 
-Defined in: [types.ts:28](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L28)
+Defined in: [types.ts:28](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L28)
 
 In-memory storage that doesn't persist data across page reloads

--- a/docs/@trust0/ridb/enumerations/StorageType.md
+++ b/docs/@trust0/ridb/enumerations/StorageType.md
@@ -6,7 +6,7 @@
 
 # Enumeration: StorageType
 
-Defined in: [types.ts:24](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L24)
+Defined in: [types.ts:24](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L24)
 
 Enumeration of built-in storage types supported by RIDB.
 
@@ -16,7 +16,7 @@ Enumeration of built-in storage types supported by RIDB.
 
 > **IndexDB**: `"IndexDB"`
 
-Defined in: [types.ts:33](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L33)
+Defined in: [types.ts:33](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L33)
 
 IndexedDB-based storage for persistent data in the browser
 
@@ -26,6 +26,6 @@ IndexedDB-based storage for persistent data in the browser
 
 > **InMemory**: `"InMemory"`
 
-Defined in: [types.ts:28](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L28)
+Defined in: [types.ts:28](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L28)
 
 In-memory storage that doesn't persist data across page reloads

--- a/docs/@trust0/ridb/enumerations/StorageType.md
+++ b/docs/@trust0/ridb/enumerations/StorageType.md
@@ -6,7 +6,7 @@
 
 # Enumeration: StorageType
 
-Defined in: [types.ts:24](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L24)
+Defined in: [types.ts:24](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L24)
 
 Enumeration of built-in storage types supported by RIDB.
 
@@ -16,7 +16,7 @@ Enumeration of built-in storage types supported by RIDB.
 
 > **IndexDB**: `"IndexDB"`
 
-Defined in: [types.ts:33](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L33)
+Defined in: [types.ts:33](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L33)
 
 IndexedDB-based storage for persistent data in the browser
 
@@ -26,6 +26,6 @@ IndexedDB-based storage for persistent data in the browser
 
 > **InMemory**: `"InMemory"`
 
-Defined in: [types.ts:28](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L28)
+Defined in: [types.ts:28](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L28)
 
 In-memory storage that doesn't persist data across page reloads

--- a/docs/@trust0/ridb/enumerations/StorageType.md
+++ b/docs/@trust0/ridb/enumerations/StorageType.md
@@ -6,7 +6,7 @@
 
 # Enumeration: StorageType
 
-Defined in: [types.ts:24](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L24)
+Defined in: [types.ts:24](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L24)
 
 Enumeration of built-in storage types supported by RIDB.
 
@@ -16,7 +16,7 @@ Enumeration of built-in storage types supported by RIDB.
 
 > **IndexDB**: `"IndexDB"`
 
-Defined in: [types.ts:33](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L33)
+Defined in: [types.ts:33](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L33)
 
 IndexedDB-based storage for persistent data in the browser
 
@@ -26,6 +26,6 @@ IndexedDB-based storage for persistent data in the browser
 
 > **InMemory**: `"InMemory"`
 
-Defined in: [types.ts:28](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L28)
+Defined in: [types.ts:28](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L28)
 
 In-memory storage that doesn't persist data across page reloads

--- a/docs/@trust0/ridb/enumerations/StorageType.md
+++ b/docs/@trust0/ridb/enumerations/StorageType.md
@@ -6,7 +6,7 @@
 
 # Enumeration: StorageType
 
-Defined in: [types.ts:24](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L24)
+Defined in: [types.ts:24](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L24)
 
 Enumeration of built-in storage types supported by RIDB.
 
@@ -16,7 +16,7 @@ Enumeration of built-in storage types supported by RIDB.
 
 > **IndexDB**: `"IndexDB"`
 
-Defined in: [types.ts:33](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L33)
+Defined in: [types.ts:33](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L33)
 
 IndexedDB-based storage for persistent data in the browser
 
@@ -26,6 +26,6 @@ IndexedDB-based storage for persistent data in the browser
 
 > **InMemory**: `"InMemory"`
 
-Defined in: [types.ts:28](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L28)
+Defined in: [types.ts:28](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L28)
 
 In-memory storage that doesn't persist data across page reloads

--- a/docs/@trust0/ridb/functions/WasmInternal.md
+++ b/docs/@trust0/ridb/functions/WasmInternal.md
@@ -8,7 +8,7 @@
 
 > **WasmInternal**(): `Promise`\<`__module`\>
 
-Defined in: [wasm.ts:6](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/wasm.ts#L6)
+Defined in: [wasm.ts:6](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/wasm.ts#L6)
 
 ## Returns
 

--- a/docs/@trust0/ridb/functions/WasmInternal.md
+++ b/docs/@trust0/ridb/functions/WasmInternal.md
@@ -8,7 +8,7 @@
 
 > **WasmInternal**(): `Promise`\<`__module`\>
 
-Defined in: [wasm.ts:6](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/wasm.ts#L6)
+Defined in: [wasm.ts:6](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/wasm.ts#L6)
 
 ## Returns
 

--- a/docs/@trust0/ridb/functions/WasmInternal.md
+++ b/docs/@trust0/ridb/functions/WasmInternal.md
@@ -8,7 +8,7 @@
 
 > **WasmInternal**(): `Promise`\<`__module`\>
 
-Defined in: [wasm.ts:6](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/wasm.ts#L6)
+Defined in: [wasm.ts:6](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/wasm.ts#L6)
 
 ## Returns
 

--- a/docs/@trust0/ridb/functions/WasmInternal.md
+++ b/docs/@trust0/ridb/functions/WasmInternal.md
@@ -8,7 +8,7 @@
 
 > **WasmInternal**(): `Promise`\<`__module`\>
 
-Defined in: [wasm.ts:6](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/wasm.ts#L6)
+Defined in: [wasm.ts:6](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/wasm.ts#L6)
 
 ## Returns
 

--- a/docs/@trust0/ridb/functions/WasmInternal.md
+++ b/docs/@trust0/ridb/functions/WasmInternal.md
@@ -8,7 +8,7 @@
 
 > **WasmInternal**(): `Promise`\<`__module`\>
 
-Defined in: [wasm.ts:6](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/wasm.ts#L6)
+Defined in: [wasm.ts:6](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/wasm.ts#L6)
 
 ## Returns
 

--- a/docs/@trust0/ridb/interfaces/RIDBAbstract.md
+++ b/docs/@trust0/ridb/interfaces/RIDBAbstract.md
@@ -6,7 +6,7 @@
 
 # Interface: RIDBAbstract\<T\>
 
-Defined in: [types.ts:104](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L104)
+Defined in: [types.ts:104](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L104)
 
 Abstract interface for RIDB implementations.
 
@@ -26,7 +26,7 @@ The schema type record defining the database structure
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: [types.ts:118](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L118)
+Defined in: [types.ts:118](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L118)
 
 Close the database connection.
 
@@ -42,7 +42,7 @@ A promise that resolves when the database has been successfully closed
 
 > **getCollections**(): \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: [types.ts:125](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L125)
+Defined in: [types.ts:125](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L125)
 
 Get the collections for this database.
 
@@ -58,7 +58,7 @@ An object containing all collections defined in the schema
 
 > **isStarted**(): `boolean`
 
-Defined in: [types.ts:132](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L132)
+Defined in: [types.ts:132](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L132)
 
 Check if the database has been started.
 
@@ -74,7 +74,7 @@ True if the database is started, false otherwise
 
 > **start**(`options?`): `Promise`\<`void`\>
 
-Defined in: [types.ts:111](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L111)
+Defined in: [types.ts:111](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L111)
 
 Start the database with the given options.
 

--- a/docs/@trust0/ridb/interfaces/RIDBAbstract.md
+++ b/docs/@trust0/ridb/interfaces/RIDBAbstract.md
@@ -6,7 +6,7 @@
 
 # Interface: RIDBAbstract\<T\>
 
-Defined in: [types.ts:104](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L104)
+Defined in: [types.ts:104](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L104)
 
 Abstract interface for RIDB implementations.
 
@@ -26,7 +26,7 @@ The schema type record defining the database structure
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: [types.ts:118](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L118)
+Defined in: [types.ts:118](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L118)
 
 Close the database connection.
 
@@ -42,7 +42,7 @@ A promise that resolves when the database has been successfully closed
 
 > **getCollections**(): \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: [types.ts:125](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L125)
+Defined in: [types.ts:125](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L125)
 
 Get the collections for this database.
 
@@ -58,7 +58,7 @@ An object containing all collections defined in the schema
 
 > **isStarted**(): `boolean`
 
-Defined in: [types.ts:132](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L132)
+Defined in: [types.ts:132](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L132)
 
 Check if the database has been started.
 
@@ -74,7 +74,7 @@ True if the database is started, false otherwise
 
 > **start**(`options?`): `Promise`\<`void`\>
 
-Defined in: [types.ts:111](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L111)
+Defined in: [types.ts:111](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L111)
 
 Start the database with the given options.
 

--- a/docs/@trust0/ridb/interfaces/RIDBAbstract.md
+++ b/docs/@trust0/ridb/interfaces/RIDBAbstract.md
@@ -6,7 +6,7 @@
 
 # Interface: RIDBAbstract\<T\>
 
-Defined in: [types.ts:104](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L104)
+Defined in: [types.ts:104](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L104)
 
 Abstract interface for RIDB implementations.
 
@@ -26,7 +26,7 @@ The schema type record defining the database structure
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: [types.ts:118](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L118)
+Defined in: [types.ts:118](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L118)
 
 Close the database connection.
 
@@ -42,7 +42,7 @@ A promise that resolves when the database has been successfully closed
 
 > **getCollections**(): \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: [types.ts:125](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L125)
+Defined in: [types.ts:125](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L125)
 
 Get the collections for this database.
 
@@ -58,7 +58,7 @@ An object containing all collections defined in the schema
 
 > **isStarted**(): `boolean`
 
-Defined in: [types.ts:132](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L132)
+Defined in: [types.ts:132](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L132)
 
 Check if the database has been started.
 
@@ -74,7 +74,7 @@ True if the database is started, false otherwise
 
 > **start**(`options?`): `Promise`\<`void`\>
 
-Defined in: [types.ts:111](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L111)
+Defined in: [types.ts:111](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L111)
 
 Start the database with the given options.
 

--- a/docs/@trust0/ridb/interfaces/RIDBAbstract.md
+++ b/docs/@trust0/ridb/interfaces/RIDBAbstract.md
@@ -6,7 +6,7 @@
 
 # Interface: RIDBAbstract\<T\>
 
-Defined in: [types.ts:104](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L104)
+Defined in: [types.ts:104](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L104)
 
 Abstract interface for RIDB implementations.
 
@@ -26,7 +26,7 @@ The schema type record defining the database structure
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: [types.ts:118](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L118)
+Defined in: [types.ts:118](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L118)
 
 Close the database connection.
 
@@ -42,7 +42,7 @@ A promise that resolves when the database has been successfully closed
 
 > **getCollections**(): \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: [types.ts:125](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L125)
+Defined in: [types.ts:125](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L125)
 
 Get the collections for this database.
 
@@ -58,7 +58,7 @@ An object containing all collections defined in the schema
 
 > **isStarted**(): `boolean`
 
-Defined in: [types.ts:132](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L132)
+Defined in: [types.ts:132](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L132)
 
 Check if the database has been started.
 
@@ -74,7 +74,7 @@ True if the database is started, false otherwise
 
 > **start**(`options?`): `Promise`\<`void`\>
 
-Defined in: [types.ts:111](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L111)
+Defined in: [types.ts:111](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L111)
 
 Start the database with the given options.
 

--- a/docs/@trust0/ridb/interfaces/RIDBAbstract.md
+++ b/docs/@trust0/ridb/interfaces/RIDBAbstract.md
@@ -6,7 +6,7 @@
 
 # Interface: RIDBAbstract\<T\>
 
-Defined in: [types.ts:104](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L104)
+Defined in: [types.ts:104](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L104)
 
 Abstract interface for RIDB implementations.
 
@@ -26,7 +26,7 @@ The schema type record defining the database structure
 
 > **close**(): `Promise`\<`void`\>
 
-Defined in: [types.ts:118](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L118)
+Defined in: [types.ts:118](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L118)
 
 Close the database connection.
 
@@ -42,7 +42,7 @@ A promise that resolves when the database has been successfully closed
 
 > **getCollections**(): \{ \[name in string \| number \| symbol\]: Collection\<Schema\<T\[name\]\>\> \}
 
-Defined in: [types.ts:125](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L125)
+Defined in: [types.ts:125](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L125)
 
 Get the collections for this database.
 
@@ -58,7 +58,7 @@ An object containing all collections defined in the schema
 
 > **isStarted**(): `boolean`
 
-Defined in: [types.ts:132](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L132)
+Defined in: [types.ts:132](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L132)
 
 Check if the database has been started.
 
@@ -74,7 +74,7 @@ True if the database is started, false otherwise
 
 > **start**(`options?`): `Promise`\<`void`\>
 
-Defined in: [types.ts:111](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L111)
+Defined in: [types.ts:111](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L111)
 
 Start the database with the given options.
 

--- a/docs/@trust0/ridb/interfaces/WorkerInstance.md
+++ b/docs/@trust0/ridb/interfaces/WorkerInstance.md
@@ -6,7 +6,7 @@
 
 # Interface: WorkerInstance
 
-Defined in: [types.ts:138](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L138)
+Defined in: [types.ts:138](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L138)
 
 Interface representing a shared worker instance and its session ID.
 
@@ -16,7 +16,7 @@ Interface representing a shared worker instance and its session ID.
 
 > **sessionId**: `string`
 
-Defined in: [types.ts:147](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L147)
+Defined in: [types.ts:147](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L147)
 
 Unique session ID for this worker connection
 
@@ -26,6 +26,6 @@ Unique session ID for this worker connection
 
 > **worker**: `SharedWorker`
 
-Defined in: [types.ts:142](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L142)
+Defined in: [types.ts:142](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L142)
 
 The SharedWorker instance

--- a/docs/@trust0/ridb/interfaces/WorkerInstance.md
+++ b/docs/@trust0/ridb/interfaces/WorkerInstance.md
@@ -6,7 +6,7 @@
 
 # Interface: WorkerInstance
 
-Defined in: [types.ts:138](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L138)
+Defined in: [types.ts:138](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L138)
 
 Interface representing a shared worker instance and its session ID.
 
@@ -16,7 +16,7 @@ Interface representing a shared worker instance and its session ID.
 
 > **sessionId**: `string`
 
-Defined in: [types.ts:147](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L147)
+Defined in: [types.ts:147](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L147)
 
 Unique session ID for this worker connection
 
@@ -26,6 +26,6 @@ Unique session ID for this worker connection
 
 > **worker**: `SharedWorker`
 
-Defined in: [types.ts:142](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L142)
+Defined in: [types.ts:142](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L142)
 
 The SharedWorker instance

--- a/docs/@trust0/ridb/interfaces/WorkerInstance.md
+++ b/docs/@trust0/ridb/interfaces/WorkerInstance.md
@@ -6,7 +6,7 @@
 
 # Interface: WorkerInstance
 
-Defined in: [types.ts:138](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L138)
+Defined in: [types.ts:138](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L138)
 
 Interface representing a shared worker instance and its session ID.
 
@@ -16,7 +16,7 @@ Interface representing a shared worker instance and its session ID.
 
 > **sessionId**: `string`
 
-Defined in: [types.ts:147](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L147)
+Defined in: [types.ts:147](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L147)
 
 Unique session ID for this worker connection
 
@@ -26,6 +26,6 @@ Unique session ID for this worker connection
 
 > **worker**: `SharedWorker`
 
-Defined in: [types.ts:142](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L142)
+Defined in: [types.ts:142](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L142)
 
 The SharedWorker instance

--- a/docs/@trust0/ridb/interfaces/WorkerInstance.md
+++ b/docs/@trust0/ridb/interfaces/WorkerInstance.md
@@ -6,7 +6,7 @@
 
 # Interface: WorkerInstance
 
-Defined in: [types.ts:138](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L138)
+Defined in: [types.ts:138](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L138)
 
 Interface representing a shared worker instance and its session ID.
 
@@ -16,7 +16,7 @@ Interface representing a shared worker instance and its session ID.
 
 > **sessionId**: `string`
 
-Defined in: [types.ts:147](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L147)
+Defined in: [types.ts:147](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L147)
 
 Unique session ID for this worker connection
 
@@ -26,6 +26,6 @@ Unique session ID for this worker connection
 
 > **worker**: `SharedWorker`
 
-Defined in: [types.ts:142](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L142)
+Defined in: [types.ts:142](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L142)
 
 The SharedWorker instance

--- a/docs/@trust0/ridb/interfaces/WorkerInstance.md
+++ b/docs/@trust0/ridb/interfaces/WorkerInstance.md
@@ -6,7 +6,7 @@
 
 # Interface: WorkerInstance
 
-Defined in: [types.ts:138](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L138)
+Defined in: [types.ts:138](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L138)
 
 Interface representing a shared worker instance and its session ID.
 
@@ -16,7 +16,7 @@ Interface representing a shared worker instance and its session ID.
 
 > **sessionId**: `string`
 
-Defined in: [types.ts:147](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L147)
+Defined in: [types.ts:147](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L147)
 
 Unique session ID for this worker connection
 
@@ -26,6 +26,6 @@ Unique session ID for this worker connection
 
 > **worker**: `SharedWorker`
 
-Defined in: [types.ts:142](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L142)
+Defined in: [types.ts:142](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L142)
 
 The SharedWorker instance

--- a/docs/@trust0/ridb/type-aliases/DBOptions.md
+++ b/docs/@trust0/ridb/type-aliases/DBOptions.md
@@ -8,7 +8,7 @@
 
 > **DBOptions**\<`T`\> = `object` & [`MigrationsParameter`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/type-aliases/MigrationsParameter.md)\<`T`\>
 
-Defined in: [types.ts:68](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L68)
+Defined in: [types.ts:68](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L68)
 
 Options for initializing the RIDB database.
 

--- a/docs/@trust0/ridb/type-aliases/DBOptions.md
+++ b/docs/@trust0/ridb/type-aliases/DBOptions.md
@@ -8,7 +8,7 @@
 
 > **DBOptions**\<`T`\> = `object` & [`MigrationsParameter`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/type-aliases/MigrationsParameter.md)\<`T`\>
 
-Defined in: [types.ts:68](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L68)
+Defined in: [types.ts:68](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L68)
 
 Options for initializing the RIDB database.
 

--- a/docs/@trust0/ridb/type-aliases/DBOptions.md
+++ b/docs/@trust0/ridb/type-aliases/DBOptions.md
@@ -8,7 +8,7 @@
 
 > **DBOptions**\<`T`\> = `object` & [`MigrationsParameter`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/type-aliases/MigrationsParameter.md)\<`T`\>
 
-Defined in: [types.ts:68](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L68)
+Defined in: [types.ts:68](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L68)
 
 Options for initializing the RIDB database.
 

--- a/docs/@trust0/ridb/type-aliases/DBOptions.md
+++ b/docs/@trust0/ridb/type-aliases/DBOptions.md
@@ -8,7 +8,7 @@
 
 > **DBOptions**\<`T`\> = `object` & [`MigrationsParameter`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/type-aliases/MigrationsParameter.md)\<`T`\>
 
-Defined in: [types.ts:68](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L68)
+Defined in: [types.ts:68](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L68)
 
 Options for initializing the RIDB database.
 

--- a/docs/@trust0/ridb/type-aliases/DBOptions.md
+++ b/docs/@trust0/ridb/type-aliases/DBOptions.md
@@ -8,7 +8,7 @@
 
 > **DBOptions**\<`T`\> = `object` & [`MigrationsParameter`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/type-aliases/MigrationsParameter.md)\<`T`\>
 
-Defined in: [types.ts:68](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L68)
+Defined in: [types.ts:68](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L68)
 
 Options for initializing the RIDB database.
 

--- a/docs/@trust0/ridb/type-aliases/PendingRequests.md
+++ b/docs/@trust0/ridb/type-aliases/PendingRequests.md
@@ -8,6 +8,6 @@
 
 > **PendingRequests** = `Map`\<`string`, \{ `reject`: (`err`) => `void`; `resolve`: (`resp`) => `void`; \}\>
 
-Defined in: [types.ts:95](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L95)
+Defined in: [types.ts:95](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L95)
 
 Map of pending requests used for worker communication.

--- a/docs/@trust0/ridb/type-aliases/PendingRequests.md
+++ b/docs/@trust0/ridb/type-aliases/PendingRequests.md
@@ -8,6 +8,6 @@
 
 > **PendingRequests** = `Map`\<`string`, \{ `reject`: (`err`) => `void`; `resolve`: (`resp`) => `void`; \}\>
 
-Defined in: [types.ts:95](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L95)
+Defined in: [types.ts:95](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L95)
 
 Map of pending requests used for worker communication.

--- a/docs/@trust0/ridb/type-aliases/PendingRequests.md
+++ b/docs/@trust0/ridb/type-aliases/PendingRequests.md
@@ -8,6 +8,6 @@
 
 > **PendingRequests** = `Map`\<`string`, \{ `reject`: (`err`) => `void`; `resolve`: (`resp`) => `void`; \}\>
 
-Defined in: [types.ts:95](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L95)
+Defined in: [types.ts:95](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L95)
 
 Map of pending requests used for worker communication.

--- a/docs/@trust0/ridb/type-aliases/PendingRequests.md
+++ b/docs/@trust0/ridb/type-aliases/PendingRequests.md
@@ -8,6 +8,6 @@
 
 > **PendingRequests** = `Map`\<`string`, \{ `reject`: (`err`) => `void`; `resolve`: (`resp`) => `void`; \}\>
 
-Defined in: [types.ts:95](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L95)
+Defined in: [types.ts:95](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L95)
 
 Map of pending requests used for worker communication.

--- a/docs/@trust0/ridb/type-aliases/PendingRequests.md
+++ b/docs/@trust0/ridb/type-aliases/PendingRequests.md
@@ -8,6 +8,6 @@
 
 > **PendingRequests** = `Map`\<`string`, \{ `reject`: (`err`) => `void`; `resolve`: (`resp`) => `void`; \}\>
 
-Defined in: [types.ts:95](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L95)
+Defined in: [types.ts:95](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L95)
 
 Map of pending requests used for worker communication.

--- a/docs/@trust0/ridb/type-aliases/StartOptions.md
+++ b/docs/@trust0/ridb/type-aliases/StartOptions.md
@@ -8,7 +8,7 @@
 
 > **StartOptions**\<`T`\> = `object`
 
-Defined in: [types.ts:41](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L41)
+Defined in: [types.ts:41](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L41)
 
 Options for starting a database instance.
 
@@ -32,7 +32,7 @@ Additional custom options
 
 > `optional` **dbName**: `string`
 
-Defined in: [types.ts:55](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L55)
+Defined in: [types.ts:55](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L55)
 
 Database name to use (overrides the name provided during initialization)
 
@@ -42,7 +42,7 @@ Database name to use (overrides the name provided during initialization)
 
 > `optional` **password**: `string`
 
-Defined in: [types.ts:50](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L50)
+Defined in: [types.ts:50](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L50)
 
 Optional password for encrypting the database
 
@@ -52,6 +52,6 @@ Optional password for encrypting the database
 
 > `optional` **storageType**: [`StorageClass`](StorageClass.md)\<`T`\> \| [`StorageType`](../enumerations/StorageType.md)
 
-Defined in: [types.ts:45](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L45)
+Defined in: [types.ts:45](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L45)
 
 The storage type or custom storage class implementation to use

--- a/docs/@trust0/ridb/type-aliases/StartOptions.md
+++ b/docs/@trust0/ridb/type-aliases/StartOptions.md
@@ -8,7 +8,7 @@
 
 > **StartOptions**\<`T`\> = `object`
 
-Defined in: [types.ts:41](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L41)
+Defined in: [types.ts:41](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L41)
 
 Options for starting a database instance.
 
@@ -32,7 +32,7 @@ Additional custom options
 
 > `optional` **dbName**: `string`
 
-Defined in: [types.ts:55](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L55)
+Defined in: [types.ts:55](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L55)
 
 Database name to use (overrides the name provided during initialization)
 
@@ -42,7 +42,7 @@ Database name to use (overrides the name provided during initialization)
 
 > `optional` **password**: `string`
 
-Defined in: [types.ts:50](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L50)
+Defined in: [types.ts:50](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L50)
 
 Optional password for encrypting the database
 
@@ -52,6 +52,6 @@ Optional password for encrypting the database
 
 > `optional` **storageType**: [`StorageClass`](StorageClass.md)\<`T`\> \| [`StorageType`](../enumerations/StorageType.md)
 
-Defined in: [types.ts:45](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L45)
+Defined in: [types.ts:45](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L45)
 
 The storage type or custom storage class implementation to use

--- a/docs/@trust0/ridb/type-aliases/StartOptions.md
+++ b/docs/@trust0/ridb/type-aliases/StartOptions.md
@@ -8,7 +8,7 @@
 
 > **StartOptions**\<`T`\> = `object`
 
-Defined in: [types.ts:41](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L41)
+Defined in: [types.ts:41](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L41)
 
 Options for starting a database instance.
 
@@ -32,7 +32,7 @@ Additional custom options
 
 > `optional` **dbName**: `string`
 
-Defined in: [types.ts:55](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L55)
+Defined in: [types.ts:55](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L55)
 
 Database name to use (overrides the name provided during initialization)
 
@@ -42,7 +42,7 @@ Database name to use (overrides the name provided during initialization)
 
 > `optional` **password**: `string`
 
-Defined in: [types.ts:50](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L50)
+Defined in: [types.ts:50](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L50)
 
 Optional password for encrypting the database
 
@@ -52,6 +52,6 @@ Optional password for encrypting the database
 
 > `optional` **storageType**: [`StorageClass`](StorageClass.md)\<`T`\> \| [`StorageType`](../enumerations/StorageType.md)
 
-Defined in: [types.ts:45](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L45)
+Defined in: [types.ts:45](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L45)
 
 The storage type or custom storage class implementation to use

--- a/docs/@trust0/ridb/type-aliases/StartOptions.md
+++ b/docs/@trust0/ridb/type-aliases/StartOptions.md
@@ -8,7 +8,7 @@
 
 > **StartOptions**\<`T`\> = `object`
 
-Defined in: [types.ts:41](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L41)
+Defined in: [types.ts:41](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L41)
 
 Options for starting a database instance.
 
@@ -32,7 +32,7 @@ Additional custom options
 
 > `optional` **dbName**: `string`
 
-Defined in: [types.ts:55](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L55)
+Defined in: [types.ts:55](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L55)
 
 Database name to use (overrides the name provided during initialization)
 
@@ -42,7 +42,7 @@ Database name to use (overrides the name provided during initialization)
 
 > `optional` **password**: `string`
 
-Defined in: [types.ts:50](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L50)
+Defined in: [types.ts:50](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L50)
 
 Optional password for encrypting the database
 
@@ -52,6 +52,6 @@ Optional password for encrypting the database
 
 > `optional` **storageType**: [`StorageClass`](StorageClass.md)\<`T`\> \| [`StorageType`](../enumerations/StorageType.md)
 
-Defined in: [types.ts:45](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L45)
+Defined in: [types.ts:45](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L45)
 
 The storage type or custom storage class implementation to use

--- a/docs/@trust0/ridb/type-aliases/StartOptions.md
+++ b/docs/@trust0/ridb/type-aliases/StartOptions.md
@@ -8,7 +8,7 @@
 
 > **StartOptions**\<`T`\> = `object`
 
-Defined in: [types.ts:41](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L41)
+Defined in: [types.ts:41](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L41)
 
 Options for starting a database instance.
 
@@ -32,7 +32,7 @@ Additional custom options
 
 > `optional` **dbName**: `string`
 
-Defined in: [types.ts:55](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L55)
+Defined in: [types.ts:55](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L55)
 
 Database name to use (overrides the name provided during initialization)
 
@@ -42,7 +42,7 @@ Database name to use (overrides the name provided during initialization)
 
 > `optional` **password**: `string`
 
-Defined in: [types.ts:50](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L50)
+Defined in: [types.ts:50](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L50)
 
 Optional password for encrypting the database
 
@@ -52,6 +52,6 @@ Optional password for encrypting the database
 
 > `optional` **storageType**: [`StorageClass`](StorageClass.md)\<`T`\> \| [`StorageType`](../enumerations/StorageType.md)
 
-Defined in: [types.ts:45](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L45)
+Defined in: [types.ts:45](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L45)
 
 The storage type or custom storage class implementation to use

--- a/docs/@trust0/ridb/type-aliases/StorageClass.md
+++ b/docs/@trust0/ridb/type-aliases/StorageClass.md
@@ -8,7 +8,7 @@
 
 > **StorageClass**\<`T`\> = `object`
 
-Defined in: [types.ts:9](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L9)
+Defined in: [types.ts:9](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L9)
 
 Represents a factory class for creating storage instances.
 
@@ -26,7 +26,7 @@ The schema type record defining the database structure
 
 > **create**: (`name`, `schemas`, `options`) => `Promise`\<[`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\<`T`\>\>
 
-Defined in: [types.ts:18](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L18)
+Defined in: [types.ts:18](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L18)
 
 Creates a storage instance with the specified parameters.
 

--- a/docs/@trust0/ridb/type-aliases/StorageClass.md
+++ b/docs/@trust0/ridb/type-aliases/StorageClass.md
@@ -8,7 +8,7 @@
 
 > **StorageClass**\<`T`\> = `object`
 
-Defined in: [types.ts:9](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L9)
+Defined in: [types.ts:9](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L9)
 
 Represents a factory class for creating storage instances.
 
@@ -26,7 +26,7 @@ The schema type record defining the database structure
 
 > **create**: (`name`, `schemas`, `options`) => `Promise`\<[`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\<`T`\>\>
 
-Defined in: [types.ts:18](https://github.com/trust0-project/RIDB/blob/03ec8397ac4b0e587e94b0dd24d9e2743c4513f0/packages/ridb/src/types.ts#L18)
+Defined in: [types.ts:18](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L18)
 
 Creates a storage instance with the specified parameters.
 

--- a/docs/@trust0/ridb/type-aliases/StorageClass.md
+++ b/docs/@trust0/ridb/type-aliases/StorageClass.md
@@ -8,7 +8,7 @@
 
 > **StorageClass**\<`T`\> = `object`
 
-Defined in: [types.ts:9](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L9)
+Defined in: [types.ts:9](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L9)
 
 Represents a factory class for creating storage instances.
 
@@ -26,7 +26,7 @@ The schema type record defining the database structure
 
 > **create**: (`name`, `schemas`, `options`) => `Promise`\<[`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\<`T`\>\>
 
-Defined in: [types.ts:18](https://github.com/trust0-project/RIDB/blob/1178ca486da4caadbba0b876f695393e5ef3243c/packages/ridb/src/types.ts#L18)
+Defined in: [types.ts:18](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L18)
 
 Creates a storage instance with the specified parameters.
 

--- a/docs/@trust0/ridb/type-aliases/StorageClass.md
+++ b/docs/@trust0/ridb/type-aliases/StorageClass.md
@@ -8,7 +8,7 @@
 
 > **StorageClass**\<`T`\> = `object`
 
-Defined in: [types.ts:9](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L9)
+Defined in: [types.ts:9](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L9)
 
 Represents a factory class for creating storage instances.
 
@@ -26,7 +26,7 @@ The schema type record defining the database structure
 
 > **create**: (`name`, `schemas`, `options`) => `Promise`\<[`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\<`T`\>\>
 
-Defined in: [types.ts:18](https://github.com/trust0-project/RIDB/blob/9786676f4132a55aaec34d1edb0da16200ab0eba/packages/ridb/src/types.ts#L18)
+Defined in: [types.ts:18](https://github.com/trust0-project/RIDB/blob/03bccbe2ed2bfcff056ffa0dc21ae7b9c17755fa/packages/ridb/src/types.ts#L18)
 
 Creates a storage instance with the specified parameters.
 

--- a/docs/@trust0/ridb/type-aliases/StorageClass.md
+++ b/docs/@trust0/ridb/type-aliases/StorageClass.md
@@ -8,7 +8,7 @@
 
 > **StorageClass**\<`T`\> = `object`
 
-Defined in: [types.ts:9](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L9)
+Defined in: [types.ts:9](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L9)
 
 Represents a factory class for creating storage instances.
 
@@ -26,7 +26,7 @@ The schema type record defining the database structure
 
 > **create**: (`name`, `schemas`, `options`) => `Promise`\<[`BaseStorage`](https://github.com/trust0-project/RIDB/blob/main/docs/%40trust0/ridb-core/classes/BaseStorage.md)\<`T`\>\>
 
-Defined in: [types.ts:18](https://github.com/trust0-project/RIDB/blob/766b641e98fdfe930e51e9b247247a842eab26d8/packages/ridb/src/types.ts#L18)
+Defined in: [types.ts:18](https://github.com/trust0-project/RIDB/blob/91e7813a35b584c4be51c3ad177dcd0789b2b572/packages/ridb/src/types.ts#L18)
 
 Creates a storage instance with the specified parameters.
 

--- a/packages/ridb-build/.gitignore
+++ b/packages/ridb-build/.gitignore
@@ -4,8 +4,6 @@ esm/*
 umd/*
 .idea
 coverage
-./build
-build/*
 build
 node_modules
 .nx

--- a/packages/ridb-core/CHANGELOG.md
+++ b/packages/ridb-core/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.7.33 (2025-09-06)
+
+### 🩹 Fixes
+
+- query improvements ([03ec839](https://github.com/trust0-project/RIDB/commit/03ec839))
+- indexDB Storage ([0711c62](https://github.com/trust0-project/RIDB/commit/0711c62))
+
+### ❤️ Thank You
+
+- Javier Ribó
+
 ## 1.7.32 (2025-09-06)
 
 ### 🩹 Fixes

--- a/packages/ridb-core/CHANGELOG.md
+++ b/packages/ridb-core/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.7.36 (2025-09-06)
+
+### 🩹 Fixes
+
+- improve indexdb ([03bccbe](https://github.com/trust0-project/RIDB/commit/03bccbe))
+
+### ❤️ Thank You
+
+- Javier Ribó
+
 ## 1.7.35 (2025-09-06)
 
 ### 🩹 Fixes

--- a/packages/ridb-core/CHANGELOG.md
+++ b/packages/ridb-core/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.7.34 (2025-09-06)
+
+### 🩹 Fixes
+
+- refactor ridb for better performance ([1178ca4](https://github.com/trust0-project/RIDB/commit/1178ca4))
+
+### ❤️ Thank You
+
+- Javier Ribó
+
 ## 1.7.33 (2025-09-06)
 
 ### 🩹 Fixes

--- a/packages/ridb-core/CHANGELOG.md
+++ b/packages/ridb-core/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.7.35 (2025-09-06)
+
+### 🩹 Fixes
+
+- manage indexdb  onsuccess onerror handlers efficiently ([9786676](https://github.com/trust0-project/RIDB/commit/9786676))
+
+### ❤️ Thank You
+
+- Javier Ribó
+
 ## 1.7.34 (2025-09-06)
 
 ### 🩹 Fixes

--- a/packages/ridb-core/package.json
+++ b/packages/ridb-core/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.7.34",
+  "version": "1.7.35",
   "main": "./build/ridb_core.js",
   "module": "./build/ridb_core.mjs",
   "types": "./build/ridb_core.d.ts",

--- a/packages/ridb-core/package.json
+++ b/packages/ridb-core/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.7.35",
+  "version": "1.7.36",
   "main": "./build/ridb_core.js",
   "module": "./build/ridb_core.mjs",
   "types": "./build/ridb_core.d.ts",

--- a/packages/ridb-core/package.json
+++ b/packages/ridb-core/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.7.32",
+  "version": "1.7.33",
   "main": "./build/ridb_core.js",
   "module": "./build/ridb_core.mjs",
   "types": "./build/ridb_core.d.ts",

--- a/packages/ridb-core/package.json
+++ b/packages/ridb-core/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.7.33",
+  "version": "1.7.34",
   "main": "./build/ridb_core.js",
   "module": "./build/ridb_core.mjs",
   "types": "./build/ridb_core.d.ts",

--- a/packages/ridb-core/package.json
+++ b/packages/ridb-core/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@esbuild-plugins/node-resolve": "^0.2.2",
-    "@trust0/ridb-build": "^0.0.21",
+    "@trust0/ridb-build": "workspace:*",
     "esbuild": "^0.25.4"
   },
   "files": [

--- a/packages/ridb-core/src/plugin/mod.rs
+++ b/packages/ridb-core/src/plugin/mod.rs
@@ -4,7 +4,8 @@ pub mod integrity;
 pub mod defaults;
 pub mod dates;
 
-use std::cell::RefCell;
+use parking_lot::RwLock;
+use std::sync::Arc;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::*;
 use js_sys::Reflect;
@@ -32,8 +33,8 @@ export class BasePlugin implements BasePluginOptions {
 #[wasm_bindgen(skip_typescript)]
 #[derive(Clone)]
 pub struct BasePlugin {
-    pub(crate) doc_create_hook: RefCell<JsValue>,
-    pub(crate) doc_recover_hook: RefCell<JsValue>,
+    pub(crate) doc_create_hook: Arc<RwLock<JsValue>>,
+    pub(crate) doc_recover_hook: Arc<RwLock<JsValue>>,
     pub(crate) name: String,
 }
 
@@ -44,8 +45,8 @@ impl BasePlugin {
     pub fn new(name: String) -> Result<BasePlugin, RIDBError> {
         Ok(BasePlugin {
             name,
-            doc_create_hook: RefCell::new(JsValue::undefined()),
-            doc_recover_hook: RefCell::new(JsValue::undefined()),
+            doc_create_hook: Arc::new(RwLock::new(JsValue::undefined())),
+            doc_recover_hook: Arc::new(RwLock::new(JsValue::undefined())),
         })
     }
 
@@ -56,22 +57,22 @@ impl BasePlugin {
 
     #[wasm_bindgen( getter = docCreateHook)]
     pub fn get_doc_create_hook(&self) -> JsValue {
-        self.doc_create_hook.borrow().clone()
+        self.doc_create_hook.read().clone()
     }
 
     #[wasm_bindgen( getter = docRecoverHook)]
     pub fn get_doc_recover_hook(&self) -> JsValue {
-        self.doc_recover_hook.borrow().clone()
+        self.doc_recover_hook.read().clone()
     }
 
     #[wasm_bindgen(setter = docCreateHook)]
     pub fn set_doc_create_hook(&self, hook: JsValue)  {
-        *self.doc_create_hook.borrow_mut() = hook;
+        *self.doc_create_hook.write() = hook;
     }
 
     #[wasm_bindgen( setter = docRecoverHook)]
     pub fn set_doc_recover_hook(&self, hook: JsValue) {
-        *self.doc_recover_hook.borrow_mut() = hook;
+        *self.doc_recover_hook.write() = hook;
     }
 
 }
@@ -96,10 +97,10 @@ impl JsCast for BasePlugin {
     fn unchecked_from_js(val: JsValue) -> Self {
         BasePlugin {
             name: "Name".to_string(),
-            doc_create_hook: RefCell::new(Reflect::get(&val, &JsValue::from_str("docCreateHook"))
-                .unwrap_or(JsValue::undefined())),
-            doc_recover_hook: RefCell::new(Reflect::get(&val, &JsValue::from_str("docRecoverHook"))
-                .unwrap_or(JsValue::undefined())),
+            doc_create_hook: Arc::new(RwLock::new(Reflect::get(&val, &JsValue::from_str("docCreateHook"))
+                .unwrap_or(JsValue::undefined()))),
+            doc_recover_hook: Arc::new(RwLock::new(Reflect::get(&val, &JsValue::from_str("docRecoverHook"))
+                .unwrap_or(JsValue::undefined()))),
         }
     }
 

--- a/packages/ridb-core/src/query/mod.rs
+++ b/packages/ridb-core/src/query/mod.rs
@@ -435,6 +435,34 @@ impl Query {
             ),
         }
     }
+
+    pub fn has_or_operator(&self) -> bool {
+        fn check_for_or(value: &JsValue) -> bool {
+            if value.is_object() {
+                let obj = Object::from(value.clone());
+                let keys = Object::keys(&obj);
+                for i in 0..keys.length() {
+                    let key = keys.get(i).as_string().unwrap_or_default();
+                    if key == "$or" {
+                        return true;
+                    }
+                    let val = Reflect::get(&obj, &JsValue::from(&key)).unwrap_or(JsValue::UNDEFINED);
+                    if check_for_or(&val) {
+                        return true;
+                    }
+                }
+            } else if value.is_array() {
+                let arr = Array::from(value);
+                for i in 0..arr.length() {
+                    if check_for_or(&arr.get(i)) {
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+        check_for_or(&self.query)
+    }
 }
 
 impl Query {

--- a/packages/ridb-core/src/schema/mod.rs
+++ b/packages/ridb-core/src/schema/mod.rs
@@ -147,19 +147,16 @@ impl Schema {
 
     #[wasm_bindgen(js_name="validate")]
     pub fn validate_document(&self, document: JsValue) -> Result<(), RIDBError> {
-        let schema_properties = self.properties.clone();
-
         // Collect required fields
-        let required: Vec<String> = schema_properties
+        let required: Vec<String> = self.properties
             .iter()
             .filter(|(_, prop)| prop.required.unwrap_or(true))
             .map(|(key, _)| key.clone())
             .collect();
 
         let encrypted = self.encrypted.clone().unwrap_or(Vec::new());
-        let properties = self.properties.clone();
 
-        for (key, prop) in properties {
+        for (key, prop) in &self.properties {
 
             let value = Reflect::get(&document, &JsValue::from_str(&key))
                 .map_err(|_e| {

--- a/packages/ridb-core/src/storages/indexdb/mod.rs
+++ b/packages/ridb-core/src/storages/indexdb/mod.rs
@@ -320,7 +320,11 @@ impl IndexDB {
 
         // Attempt to figure out if we can leverage a single index
         Logger::debug("IndexDB-CollectDocuments", &JsValue::from_str("Checking for index optimization"));
-        let index_name_option = can_use_single_index_lookup(query.clone(), schema)?;
+        let index_name_option = if query.has_or_operator() {
+            None
+        } else {
+            can_use_single_index_lookup(query.clone(), schema)?
+        };
 
         // Determine offset and limit
         let offset = options.offset.unwrap_or(0);

--- a/packages/ridb-core/src/storages/indexdb/utils.rs
+++ b/packages/ridb-core/src/storages/indexdb/utils.rs
@@ -118,6 +118,8 @@ pub async fn get_pks_from_index(index: &web_sys::IdbIndex, range: &JsValue) -> R
         request.set_onsuccess(Some(onsuccess.as_ref().unchecked_ref()));
         request.set_onerror(Some(onerror.as_ref().unchecked_ref()));
         onsuccess.forget();
+        // Ensure the error handler is kept alive for the lifetime of the request as well
+        onerror.forget();
     });
 
     JsFuture::from(promise).await?;

--- a/packages/ridb-core/src/storages/inmemory/mod.rs
+++ b/packages/ridb-core/src/storages/inmemory/mod.rs
@@ -56,7 +56,7 @@ impl Storage for InMemory {
             ))
         );
 
-        let schemas = self.base.schemas.borrow();
+        let schemas = self.base.schemas.read();
         let schema = schemas
             .get(op.collection.as_str())
             .ok_or_else(|| {
@@ -124,7 +124,7 @@ impl Storage for InMemory {
                         }
 
                         let primary_index_name = op.primary_key_index()?;
-                        let indexed_fields = schema.clone().indexes.unwrap_or(Vec::new());
+                        let indexed_fields = schema.indexes.as_deref().unwrap_or(&[]).to_vec();
                         for indexed_field in indexed_fields {
                             let collection_name = format!("idx_{}_{}", op.collection, indexed_field);
                             if collection_name == primary_index_name {
@@ -286,7 +286,7 @@ impl Storage for InMemory {
                 collection_name
             ))
         );
-        let schemas = self.base.schemas.borrow();
+        let schemas = self.base.schemas.read();
         let schema = schemas.get(collection_name).ok_or_else(|| {
             let msg = format!("Collection {} not found in findDocumentById", collection_name);
             Logger::debug(
@@ -451,7 +451,7 @@ impl InMemory {
         let read_lock = self.by_index.read()
             .map_err(|_| JsValue::from_str("Failed to acquire read lock"))?;
 
-        let schemas = self.base.schemas.borrow();
+        let schemas = self.base.schemas.read();
         let schema = schemas
             .get(collection_name)
             .ok_or_else(|| {
@@ -646,7 +646,7 @@ impl InMemory {
                 collection_name
             ))
         );
-        let schemas = self.base.schemas.borrow();
+        let schemas = self.base.schemas.read();
         let schema = schemas.get(collection_name)
             .ok_or_else(|| JsValue::from( format!("Collection {} not found in find", collection_name)))?;
         let query = Query::new(query_js, schema.clone())?;
@@ -678,7 +678,7 @@ impl InMemory {
                 collection_name
             ))
         );
-        let schemas = self.base.schemas.borrow();
+        let schemas = self.base.schemas.read();
         let schema = schemas.get(collection_name).ok_or_else(|| JsValue::from( format!("Collection {} not found in count", collection_name)))?;
         let query = Query::new(query_js, schema.clone())?;
         self.count(collection_name, query, options).await

--- a/packages/ridb-level/CHANGELOG.md
+++ b/packages/ridb-level/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.39 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.34
+- Updated @trust0/ridb to 1.5.39
+
 ## 1.2.38 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb-level/CHANGELOG.md
+++ b/packages/ridb-level/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.40 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.35
+- Updated @trust0/ridb to 1.5.40
+
 ## 1.2.39 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb-level/CHANGELOG.md
+++ b/packages/ridb-level/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.38 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.33
+- Updated @trust0/ridb to 1.5.38
+
 ## 1.2.37 (2025-09-06)
 
 ### 🩹 Fixes

--- a/packages/ridb-level/CHANGELOG.md
+++ b/packages/ridb-level/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.41 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.36
+- Updated @trust0/ridb to 1.5.41
+
 ## 1.2.40 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb-level/package.json
+++ b/packages/ridb-level/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb-level",
-  "version": "1.2.40",
+  "version": "1.2.41",
   "description": "Level DB storage for @trust0/ridb.",
   "main": "./build/index.js",
   "module": "./build/index.mjs",
@@ -30,13 +30,13 @@
     "types:default": "npx tsc"
   },
   "devDependencies": {
-    "@trust0/ridb": "^1.5.40",
+    "@trust0/ridb": "^1.5.41",
     "@trust0/ridb-build": "^0.0.21",
     "classic-level": "^2.0.0",
     "jsdom": "^24.1.3",
     "uuid": "^11.0.3"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.40"
+    "@trust0/ridb": "^1.5.41"
   }
 }

--- a/packages/ridb-level/package.json
+++ b/packages/ridb-level/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb-level",
-  "version": "1.2.37",
+  "version": "1.2.38",
   "description": "Level DB storage for @trust0/ridb.",
   "main": "./build/index.js",
   "module": "./build/index.mjs",
@@ -30,13 +30,13 @@
     "types:default": "npx tsc"
   },
   "devDependencies": {
-    "@trust0/ridb": "^1.5.37",
+    "@trust0/ridb": "^1.5.38",
     "@trust0/ridb-build": "^0.0.21",
     "classic-level": "^2.0.0",
     "jsdom": "^24.1.3",
     "uuid": "^11.0.3"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.37"
+    "@trust0/ridb": "^1.5.38"
   }
 }

--- a/packages/ridb-level/package.json
+++ b/packages/ridb-level/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb-level",
-  "version": "1.2.38",
+  "version": "1.2.39",
   "description": "Level DB storage for @trust0/ridb.",
   "main": "./build/index.js",
   "module": "./build/index.mjs",
@@ -30,13 +30,13 @@
     "types:default": "npx tsc"
   },
   "devDependencies": {
-    "@trust0/ridb": "^1.5.38",
+    "@trust0/ridb": "^1.5.39",
     "@trust0/ridb-build": "^0.0.21",
     "classic-level": "^2.0.0",
     "jsdom": "^24.1.3",
     "uuid": "^11.0.3"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.38"
+    "@trust0/ridb": "^1.5.39"
   }
 }

--- a/packages/ridb-level/package.json
+++ b/packages/ridb-level/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb-level",
-  "version": "1.2.39",
+  "version": "1.2.40",
   "description": "Level DB storage for @trust0/ridb.",
   "main": "./build/index.js",
   "module": "./build/index.mjs",
@@ -30,13 +30,13 @@
     "types:default": "npx tsc"
   },
   "devDependencies": {
-    "@trust0/ridb": "^1.5.39",
+    "@trust0/ridb": "^1.5.40",
     "@trust0/ridb-build": "^0.0.21",
     "classic-level": "^2.0.0",
     "jsdom": "^24.1.3",
     "uuid": "^11.0.3"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.39"
+    "@trust0/ridb": "^1.5.40"
   }
 }

--- a/packages/ridb-level/package.json
+++ b/packages/ridb-level/package.json
@@ -30,13 +30,13 @@
     "types:default": "npx tsc"
   },
   "devDependencies": {
-    "@trust0/ridb": "^1.5.41",
-    "@trust0/ridb-build": "^0.0.21",
+    "@trust0/ridb": "workspace:*",
+    "@trust0/ridb-build": "workspace:*",
     "classic-level": "^2.0.0",
     "jsdom": "^24.1.3",
     "uuid": "^11.0.3"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.41"
+    "@trust0/ridb": "workspace:*"
   }
 }

--- a/packages/ridb-mongodb/CHANGELOG.md
+++ b/packages/ridb-mongodb/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.8 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.36
+- Updated @trust0/ridb to 1.5.41
+
 ## 0.0.7 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb-mongodb/CHANGELOG.md
+++ b/packages/ridb-mongodb/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.5 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.33
+- Updated @trust0/ridb to 1.5.38
+
 ## 0.0.4 (2025-09-06)
 
 ### 🩹 Fixes

--- a/packages/ridb-mongodb/CHANGELOG.md
+++ b/packages/ridb-mongodb/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.6 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.34
+- Updated @trust0/ridb to 1.5.39
+
 ## 0.0.5 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb-mongodb/CHANGELOG.md
+++ b/packages/ridb-mongodb/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.7 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.35
+- Updated @trust0/ridb to 1.5.40
+
 ## 0.0.6 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb-mongodb/package.json
+++ b/packages/ridb-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb-mongodb",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "MongoDB storage for @trust0/ridb",
   "main": "./build/index.js",
   "module": "./build/index.mjs",
@@ -30,7 +30,7 @@
     "types:default": "npx tsc"
   },
   "devDependencies": {
-    "@trust0/ridb": "^1.5.37",
+    "@trust0/ridb": "^1.5.38",
     "@trust0/ridb-build": "^0.0.21",
     "jsdom": "^24.1.3",
     "mongodb": "^6.0.0",
@@ -39,6 +39,6 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.37"
+    "@trust0/ridb": "^1.5.38"
   }
 }

--- a/packages/ridb-mongodb/package.json
+++ b/packages/ridb-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb-mongodb",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "MongoDB storage for @trust0/ridb",
   "main": "./build/index.js",
   "module": "./build/index.mjs",
@@ -30,7 +30,7 @@
     "types:default": "npx tsc"
   },
   "devDependencies": {
-    "@trust0/ridb": "^1.5.39",
+    "@trust0/ridb": "^1.5.40",
     "@trust0/ridb-build": "^0.0.21",
     "jsdom": "^24.1.3",
     "mongodb": "^6.0.0",
@@ -39,6 +39,6 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.39"
+    "@trust0/ridb": "^1.5.40"
   }
 }

--- a/packages/ridb-mongodb/package.json
+++ b/packages/ridb-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb-mongodb",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "MongoDB storage for @trust0/ridb",
   "main": "./build/index.js",
   "module": "./build/index.mjs",
@@ -30,7 +30,7 @@
     "types:default": "npx tsc"
   },
   "devDependencies": {
-    "@trust0/ridb": "^1.5.40",
+    "@trust0/ridb": "^1.5.41",
     "@trust0/ridb-build": "^0.0.21",
     "jsdom": "^24.1.3",
     "mongodb": "^6.0.0",
@@ -39,6 +39,6 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.40"
+    "@trust0/ridb": "^1.5.41"
   }
 }

--- a/packages/ridb-mongodb/package.json
+++ b/packages/ridb-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb-mongodb",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "MongoDB storage for @trust0/ridb",
   "main": "./build/index.js",
   "module": "./build/index.mjs",
@@ -30,7 +30,7 @@
     "types:default": "npx tsc"
   },
   "devDependencies": {
-    "@trust0/ridb": "^1.5.38",
+    "@trust0/ridb": "^1.5.39",
     "@trust0/ridb-build": "^0.0.21",
     "jsdom": "^24.1.3",
     "mongodb": "^6.0.0",
@@ -39,6 +39,6 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.38"
+    "@trust0/ridb": "^1.5.39"
   }
 }

--- a/packages/ridb-mongodb/package.json
+++ b/packages/ridb-mongodb/package.json
@@ -30,8 +30,8 @@
     "types:default": "npx tsc"
   },
   "devDependencies": {
-    "@trust0/ridb": "^1.5.41",
-    "@trust0/ridb-build": "^0.0.21",
+    "@trust0/ridb": "workspace:*",
+    "@trust0/ridb-build": "workspace:*",
     "jsdom": "^24.1.3",
     "mongodb": "^6.0.0",
     "uuid": "^11.0.3",
@@ -39,6 +39,6 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.41"
+    "@trust0/ridb": "workspace:*"
   }
 }

--- a/packages/ridb-react/CHANGELOG.md
+++ b/packages/ridb-react/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.18 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.34
+- Updated @trust0/ridb to 1.5.39
+
 ## 1.4.17 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb-react/CHANGELOG.md
+++ b/packages/ridb-react/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.19 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.35
+- Updated @trust0/ridb to 1.5.40
+
 ## 1.4.18 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb-react/CHANGELOG.md
+++ b/packages/ridb-react/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.20 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.36
+- Updated @trust0/ridb to 1.5.41
+
 ## 1.4.19 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb-react/CHANGELOG.md
+++ b/packages/ridb-react/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.17 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.33
+- Updated @trust0/ridb to 1.5.38
+
 ## 1.4.16 (2025-09-06)
 
 ### 🩹 Fixes

--- a/packages/ridb-react/package.json
+++ b/packages/ridb-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trust0/ridb-react",
   "description": "React bindings for RIDB.",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "author": "elribonazo@gmail.com",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -31,7 +31,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
-    "@trust0/ridb": "^1.5.40",
+    "@trust0/ridb": "^1.5.41",
     "@trust0/ridb-build": "^0.0.21",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -39,7 +39,7 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.40",
+    "@trust0/ridb": "^1.5.41",
     "react": "^18",
     "react-dom": "^18"
   }

--- a/packages/ridb-react/package.json
+++ b/packages/ridb-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trust0/ridb-react",
   "description": "React bindings for RIDB.",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "author": "elribonazo@gmail.com",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -31,7 +31,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
-    "@trust0/ridb": "^1.5.38",
+    "@trust0/ridb": "^1.5.39",
     "@trust0/ridb-build": "^0.0.21",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -39,7 +39,7 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.38",
+    "@trust0/ridb": "^1.5.39",
     "react": "^18",
     "react-dom": "^18"
   }

--- a/packages/ridb-react/package.json
+++ b/packages/ridb-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trust0/ridb-react",
   "description": "React bindings for RIDB.",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "author": "elribonazo@gmail.com",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -31,7 +31,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
-    "@trust0/ridb": "^1.5.37",
+    "@trust0/ridb": "^1.5.38",
     "@trust0/ridb-build": "^0.0.21",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -39,7 +39,7 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.37",
+    "@trust0/ridb": "^1.5.38",
     "react": "^18",
     "react-dom": "^18"
   }

--- a/packages/ridb-react/package.json
+++ b/packages/ridb-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trust0/ridb-react",
   "description": "React bindings for RIDB.",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "author": "elribonazo@gmail.com",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -31,7 +31,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
-    "@trust0/ridb": "^1.5.39",
+    "@trust0/ridb": "^1.5.40",
     "@trust0/ridb-build": "^0.0.21",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -39,7 +39,7 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.39",
+    "@trust0/ridb": "^1.5.40",
     "react": "^18",
     "react-dom": "^18"
   }

--- a/packages/ridb-react/package.json
+++ b/packages/ridb-react/package.json
@@ -31,15 +31,15 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
-    "@trust0/ridb": "^1.5.41",
-    "@trust0/ridb-build": "^0.0.21",
+    "@trust0/ridb": "workspace:*",
+    "@trust0/ridb-build": "workspace:*",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "jsdom": "^25.0.1",
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "@trust0/ridb": "^1.5.41",
+    "@trust0/ridb": "workspace:*",
     "react": "^18",
     "react-dom": "^18"
   }

--- a/packages/ridb/CHANGELOG.md
+++ b/packages/ridb/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.38 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.33
+
 ## 1.5.37 (2025-09-06)
 
 ### 🩹 Fixes

--- a/packages/ridb/CHANGELOG.md
+++ b/packages/ridb/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.40 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.35
+
 ## 1.5.39 (2025-09-06)
 
 ### 🩹 Fixes

--- a/packages/ridb/CHANGELOG.md
+++ b/packages/ridb/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.41 (2025-09-06)
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.36
+
 ## 1.5.40 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb/CHANGELOG.md
+++ b/packages/ridb/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.5.39 (2025-09-06)
+
+### 🩹 Fixes
+
+- refactor ridb for better performance ([1178ca4](https://github.com/trust0-project/RIDB/commit/1178ca4))
+
+### 🧱 Updated Dependencies
+
+- Updated @trust0/ridb-core to 1.7.34
+
+### ❤️ Thank You
+
+- Javier Ribó
+
 ## 1.5.38 (2025-09-06)
 
 ### 🧱 Updated Dependencies

--- a/packages/ridb/package.json
+++ b/packages/ridb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb",
-  "version": "1.5.37",
+  "version": "1.5.38",
   "description": "Lightweight db encrypted and secure database wrapper for browser and nodejs.",
   "module": "./build/index.js",
   "main": "./build/index.js",
@@ -51,7 +51,7 @@
     "types": "sh types.sh"
   },
   "dependencies": {
-    "@trust0/ridb-core": "^1.7.32"
+    "@trust0/ridb-core": "^1.7.33"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",

--- a/packages/ridb/package.json
+++ b/packages/ridb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb",
-  "version": "1.5.40",
+  "version": "1.5.41",
   "description": "Lightweight db encrypted and secure database wrapper for browser and nodejs.",
   "module": "./build/index.js",
   "main": "./build/index.js",
@@ -51,7 +51,7 @@
     "types": "sh types.sh"
   },
   "dependencies": {
-    "@trust0/ridb-core": "^1.7.35"
+    "@trust0/ridb-core": "^1.7.36"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",

--- a/packages/ridb/package.json
+++ b/packages/ridb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb",
-  "version": "1.5.39",
+  "version": "1.5.40",
   "description": "Lightweight db encrypted and secure database wrapper for browser and nodejs.",
   "module": "./build/index.js",
   "main": "./build/index.js",
@@ -51,7 +51,7 @@
     "types": "sh types.sh"
   },
   "dependencies": {
-    "@trust0/ridb-core": "^1.7.34"
+    "@trust0/ridb-core": "^1.7.35"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",

--- a/packages/ridb/package.json
+++ b/packages/ridb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trust0/ridb",
-  "version": "1.5.38",
+  "version": "1.5.39",
   "description": "Lightweight db encrypted and secure database wrapper for browser and nodejs.",
   "module": "./build/index.js",
   "main": "./build/index.js",
@@ -51,7 +51,7 @@
     "types": "sh types.sh"
   },
   "dependencies": {
-    "@trust0/ridb-core": "^1.7.33"
+    "@trust0/ridb-core": "^1.7.34"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",

--- a/packages/ridb/package.json
+++ b/packages/ridb/package.json
@@ -51,11 +51,11 @@
     "types": "sh types.sh"
   },
   "dependencies": {
-    "@trust0/ridb-core": "^1.7.36"
+    "@trust0/ridb-core": "workspace:*"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",
-    "@trust0/ridb-build": "^0.0.21",
+    "@trust0/ridb-build": "workspace:*",
     "@types/sharedworker": "^0.0.150",
     "jsdom": "^24.1.3",
     "typescript": "^5.8.3",

--- a/packages/ridb/src/core.ts
+++ b/packages/ridb/src/core.ts
@@ -1,5 +1,4 @@
-import type { BasePlugin, MigrationPathsForSchemas, SchemaTypeRecord } from "@trust0/ridb-core";
-import { Database } from "@trust0/ridb-core";
+import type { BasePlugin, Database, MigrationPathsForSchemas, SchemaTypeRecord } from "@trust0/ridb-core";
 import type { DBOptions, PendingRequests, StartOptions } from "./types";
 import { StorageType } from "./types";
 
@@ -36,7 +35,7 @@ export class RIDBCore<T extends SchemaTypeRecord = SchemaTypeRecord> {
    *
    * @param options Database configuration options
    */
-  constructor(protected options: DBOptions<T>) {}
+  constructor(protected options: DBOptions<T>) { }
 
   /**
    * Gets the configured database name from options.
@@ -127,7 +126,7 @@ export class RIDBCore<T extends SchemaTypeRecord = SchemaTypeRecord> {
    * @throws Error if the storage class is invalid or if dbName is missing
    */
   protected async createDatabase(options?: StartOptions<T>) {
-    await WasmInternal();
+    const { Database } = await WasmInternal();
     const { storageType, password } = options ?? {};
     const StorageClass = typeof storageType === "string" ? await this.getStorageType(storageType) : (storageType ?? undefined);
     if (StorageClass && !StorageClass.create) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4979,7 +4979,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trust0/ridb-core@npm:^1.7.32, @trust0/ridb-core@workspace:packages/ridb-core":
+"@trust0/ridb-core@npm:^1.7.33, @trust0/ridb-core@workspace:packages/ridb-core":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-core@workspace:packages/ridb-core"
   dependencies:
@@ -4993,13 +4993,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-level@workspace:packages/ridb-level"
   dependencies:
-    "@trust0/ridb": "npm:^1.5.37"
+    "@trust0/ridb": "npm:^1.5.38"
     "@trust0/ridb-build": "npm:^0.0.21"
     classic-level: "npm:^2.0.0"
     jsdom: "npm:^24.1.3"
     uuid: "npm:^11.0.3"
   peerDependencies:
-    "@trust0/ridb": ^1.5.37
+    "@trust0/ridb": ^1.5.38
   languageName: unknown
   linkType: soft
 
@@ -5007,7 +5007,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-mongodb@workspace:packages/ridb-mongodb"
   dependencies:
-    "@trust0/ridb": "npm:^1.5.37"
+    "@trust0/ridb": "npm:^1.5.38"
     "@trust0/ridb-build": "npm:^0.0.21"
     jsdom: "npm:^24.1.3"
     mongodb: "npm:^6.0.0"
@@ -5015,7 +5015,7 @@ __metadata:
     vite: "npm:^7.0.5"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    "@trust0/ridb": ^1.5.37
+    "@trust0/ridb": ^1.5.38
   languageName: unknown
   linkType: soft
 
@@ -5027,26 +5027,26 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.1.0"
-    "@trust0/ridb": "npm:^1.5.37"
+    "@trust0/ridb": "npm:^1.5.38"
     "@trust0/ridb-build": "npm:^0.0.21"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
     jsdom: "npm:^25.0.1"
     typescript: "npm:^5.7.2"
   peerDependencies:
-    "@trust0/ridb": ^1.5.37
+    "@trust0/ridb": ^1.5.38
     react: ^18
     react-dom: ^18
   languageName: unknown
   linkType: soft
 
-"@trust0/ridb@npm:^1.5.37, @trust0/ridb@workspace:packages/ridb":
+"@trust0/ridb@npm:^1.5.38, @trust0/ridb@workspace:packages/ridb":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb@workspace:packages/ridb"
   dependencies:
     "@biomejs/biome": "npm:2.0.0"
     "@trust0/ridb-build": "npm:^0.0.21"
-    "@trust0/ridb-core": "npm:^1.7.32"
+    "@trust0/ridb-core": "npm:^1.7.33"
     "@types/sharedworker": "npm:^0.0.150"
     jsdom: "npm:^24.1.3"
     typescript: "npm:^5.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4979,7 +4979,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trust0/ridb-core@npm:^1.7.35, @trust0/ridb-core@workspace:packages/ridb-core":
+"@trust0/ridb-core@npm:^1.7.36, @trust0/ridb-core@workspace:packages/ridb-core":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-core@workspace:packages/ridb-core"
   dependencies:
@@ -4993,13 +4993,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-level@workspace:packages/ridb-level"
   dependencies:
-    "@trust0/ridb": "npm:^1.5.40"
+    "@trust0/ridb": "npm:^1.5.41"
     "@trust0/ridb-build": "npm:^0.0.21"
     classic-level: "npm:^2.0.0"
     jsdom: "npm:^24.1.3"
     uuid: "npm:^11.0.3"
   peerDependencies:
-    "@trust0/ridb": ^1.5.40
+    "@trust0/ridb": ^1.5.41
   languageName: unknown
   linkType: soft
 
@@ -5007,7 +5007,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-mongodb@workspace:packages/ridb-mongodb"
   dependencies:
-    "@trust0/ridb": "npm:^1.5.40"
+    "@trust0/ridb": "npm:^1.5.41"
     "@trust0/ridb-build": "npm:^0.0.21"
     jsdom: "npm:^24.1.3"
     mongodb: "npm:^6.0.0"
@@ -5015,7 +5015,7 @@ __metadata:
     vite: "npm:^7.0.5"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    "@trust0/ridb": ^1.5.40
+    "@trust0/ridb": ^1.5.41
   languageName: unknown
   linkType: soft
 
@@ -5027,26 +5027,26 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.1.0"
-    "@trust0/ridb": "npm:^1.5.40"
+    "@trust0/ridb": "npm:^1.5.41"
     "@trust0/ridb-build": "npm:^0.0.21"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
     jsdom: "npm:^25.0.1"
     typescript: "npm:^5.7.2"
   peerDependencies:
-    "@trust0/ridb": ^1.5.40
+    "@trust0/ridb": ^1.5.41
     react: ^18
     react-dom: ^18
   languageName: unknown
   linkType: soft
 
-"@trust0/ridb@npm:^1.5.40, @trust0/ridb@workspace:packages/ridb":
+"@trust0/ridb@npm:^1.5.41, @trust0/ridb@workspace:packages/ridb":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb@workspace:packages/ridb"
   dependencies:
     "@biomejs/biome": "npm:2.0.0"
     "@trust0/ridb-build": "npm:^0.0.21"
-    "@trust0/ridb-core": "npm:^1.7.35"
+    "@trust0/ridb-core": "npm:^1.7.36"
     "@types/sharedworker": "npm:^0.0.150"
     jsdom: "npm:^24.1.3"
     typescript: "npm:^5.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4979,7 +4979,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trust0/ridb-core@npm:^1.7.33, @trust0/ridb-core@workspace:packages/ridb-core":
+"@trust0/ridb-core@npm:^1.7.34, @trust0/ridb-core@workspace:packages/ridb-core":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-core@workspace:packages/ridb-core"
   dependencies:
@@ -4993,13 +4993,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-level@workspace:packages/ridb-level"
   dependencies:
-    "@trust0/ridb": "npm:^1.5.38"
+    "@trust0/ridb": "npm:^1.5.39"
     "@trust0/ridb-build": "npm:^0.0.21"
     classic-level: "npm:^2.0.0"
     jsdom: "npm:^24.1.3"
     uuid: "npm:^11.0.3"
   peerDependencies:
-    "@trust0/ridb": ^1.5.38
+    "@trust0/ridb": ^1.5.39
   languageName: unknown
   linkType: soft
 
@@ -5007,7 +5007,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-mongodb@workspace:packages/ridb-mongodb"
   dependencies:
-    "@trust0/ridb": "npm:^1.5.38"
+    "@trust0/ridb": "npm:^1.5.39"
     "@trust0/ridb-build": "npm:^0.0.21"
     jsdom: "npm:^24.1.3"
     mongodb: "npm:^6.0.0"
@@ -5015,7 +5015,7 @@ __metadata:
     vite: "npm:^7.0.5"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    "@trust0/ridb": ^1.5.38
+    "@trust0/ridb": ^1.5.39
   languageName: unknown
   linkType: soft
 
@@ -5027,26 +5027,26 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.1.0"
-    "@trust0/ridb": "npm:^1.5.38"
+    "@trust0/ridb": "npm:^1.5.39"
     "@trust0/ridb-build": "npm:^0.0.21"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
     jsdom: "npm:^25.0.1"
     typescript: "npm:^5.7.2"
   peerDependencies:
-    "@trust0/ridb": ^1.5.38
+    "@trust0/ridb": ^1.5.39
     react: ^18
     react-dom: ^18
   languageName: unknown
   linkType: soft
 
-"@trust0/ridb@npm:^1.5.38, @trust0/ridb@workspace:packages/ridb":
+"@trust0/ridb@npm:^1.5.39, @trust0/ridb@workspace:packages/ridb":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb@workspace:packages/ridb"
   dependencies:
     "@biomejs/biome": "npm:2.0.0"
     "@trust0/ridb-build": "npm:^0.0.21"
-    "@trust0/ridb-core": "npm:^1.7.33"
+    "@trust0/ridb-core": "npm:^1.7.34"
     "@types/sharedworker": "npm:^0.0.150"
     jsdom: "npm:^24.1.3"
     typescript: "npm:^5.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4979,7 +4979,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trust0/ridb-core@npm:^1.7.34, @trust0/ridb-core@workspace:packages/ridb-core":
+"@trust0/ridb-core@npm:^1.7.35, @trust0/ridb-core@workspace:packages/ridb-core":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-core@workspace:packages/ridb-core"
   dependencies:
@@ -4993,13 +4993,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-level@workspace:packages/ridb-level"
   dependencies:
-    "@trust0/ridb": "npm:^1.5.39"
+    "@trust0/ridb": "npm:^1.5.40"
     "@trust0/ridb-build": "npm:^0.0.21"
     classic-level: "npm:^2.0.0"
     jsdom: "npm:^24.1.3"
     uuid: "npm:^11.0.3"
   peerDependencies:
-    "@trust0/ridb": ^1.5.39
+    "@trust0/ridb": ^1.5.40
   languageName: unknown
   linkType: soft
 
@@ -5007,7 +5007,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-mongodb@workspace:packages/ridb-mongodb"
   dependencies:
-    "@trust0/ridb": "npm:^1.5.39"
+    "@trust0/ridb": "npm:^1.5.40"
     "@trust0/ridb-build": "npm:^0.0.21"
     jsdom: "npm:^24.1.3"
     mongodb: "npm:^6.0.0"
@@ -5015,7 +5015,7 @@ __metadata:
     vite: "npm:^7.0.5"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    "@trust0/ridb": ^1.5.39
+    "@trust0/ridb": ^1.5.40
   languageName: unknown
   linkType: soft
 
@@ -5027,26 +5027,26 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.1.0"
-    "@trust0/ridb": "npm:^1.5.39"
+    "@trust0/ridb": "npm:^1.5.40"
     "@trust0/ridb-build": "npm:^0.0.21"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
     jsdom: "npm:^25.0.1"
     typescript: "npm:^5.7.2"
   peerDependencies:
-    "@trust0/ridb": ^1.5.39
+    "@trust0/ridb": ^1.5.40
     react: ^18
     react-dom: ^18
   languageName: unknown
   linkType: soft
 
-"@trust0/ridb@npm:^1.5.39, @trust0/ridb@workspace:packages/ridb":
+"@trust0/ridb@npm:^1.5.40, @trust0/ridb@workspace:packages/ridb":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb@workspace:packages/ridb"
   dependencies:
     "@biomejs/biome": "npm:2.0.0"
     "@trust0/ridb-build": "npm:^0.0.21"
-    "@trust0/ridb-core": "npm:^1.7.34"
+    "@trust0/ridb-core": "npm:^1.7.35"
     "@types/sharedworker": "npm:^0.0.150"
     jsdom: "npm:^24.1.3"
     typescript: "npm:^5.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4970,7 +4970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@trust0/ridb-build@npm:^0.0.21, @trust0/ridb-build@workspace:packages/ridb-build":
+"@trust0/ridb-build@workspace:*, @trust0/ridb-build@workspace:packages/ridb-build":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-build@workspace:packages/ridb-build"
   dependencies:
@@ -4979,12 +4979,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trust0/ridb-core@npm:^1.7.36, @trust0/ridb-core@workspace:packages/ridb-core":
+"@trust0/ridb-core@workspace:*, @trust0/ridb-core@workspace:packages/ridb-core":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-core@workspace:packages/ridb-core"
   dependencies:
     "@esbuild-plugins/node-resolve": "npm:^0.2.2"
-    "@trust0/ridb-build": "npm:^0.0.21"
+    "@trust0/ridb-build": "workspace:*"
     esbuild: "npm:^0.25.4"
   languageName: unknown
   linkType: soft
@@ -4993,13 +4993,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-level@workspace:packages/ridb-level"
   dependencies:
-    "@trust0/ridb": "npm:^1.5.41"
-    "@trust0/ridb-build": "npm:^0.0.21"
+    "@trust0/ridb": "workspace:*"
+    "@trust0/ridb-build": "workspace:*"
     classic-level: "npm:^2.0.0"
     jsdom: "npm:^24.1.3"
     uuid: "npm:^11.0.3"
   peerDependencies:
-    "@trust0/ridb": ^1.5.41
+    "@trust0/ridb": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -5007,15 +5007,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trust0/ridb-mongodb@workspace:packages/ridb-mongodb"
   dependencies:
-    "@trust0/ridb": "npm:^1.5.41"
-    "@trust0/ridb-build": "npm:^0.0.21"
+    "@trust0/ridb": "workspace:*"
+    "@trust0/ridb-build": "workspace:*"
     jsdom: "npm:^24.1.3"
     mongodb: "npm:^6.0.0"
     uuid: "npm:^11.0.3"
     vite: "npm:^7.0.5"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    "@trust0/ridb": ^1.5.41
+    "@trust0/ridb": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -5027,26 +5027,26 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.1.0"
-    "@trust0/ridb": "npm:^1.5.41"
-    "@trust0/ridb-build": "npm:^0.0.21"
+    "@trust0/ridb": "workspace:*"
+    "@trust0/ridb-build": "workspace:*"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
     jsdom: "npm:^25.0.1"
     typescript: "npm:^5.7.2"
   peerDependencies:
-    "@trust0/ridb": ^1.5.41
+    "@trust0/ridb": "workspace:*"
     react: ^18
     react-dom: ^18
   languageName: unknown
   linkType: soft
 
-"@trust0/ridb@npm:^1.5.41, @trust0/ridb@workspace:packages/ridb":
+"@trust0/ridb@workspace:*, @trust0/ridb@workspace:packages/ridb":
   version: 0.0.0-use.local
   resolution: "@trust0/ridb@workspace:packages/ridb"
   dependencies:
     "@biomejs/biome": "npm:2.0.0"
-    "@trust0/ridb-build": "npm:^0.0.21"
-    "@trust0/ridb-core": "npm:^1.7.36"
+    "@trust0/ridb-build": "workspace:*"
+    "@trust0/ridb-core": "workspace:*"
     "@types/sharedworker": "npm:^0.0.150"
     jsdom: "npm:^24.1.3"
     typescript: "npm:^5.8.3"


### PR DESCRIPTION
Improve dependency management.
add npm publish provenance
load Database from WasmInternal not directy import

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core storage/query and IndexedDB execution paths (including primary-key validation and index-based cursor ranges), which can change runtime behavior and performance; also includes CI/release changes that affect publishing output.
> 
> **Overview**
> **Publishing/release:** Updates `.github/workflows/release.yml` to use Node.js `22` and enables npm provenance (`NPM_CONFIG_PROVENANCE=true`) during publish. Bumps `@trust0/ridb-core` to `1.7.36` and switches `@trust0/ridb-build` dev dependency to `workspace:*`.
> 
> **Wasm core/runtime:** Replaces several `RefCell` caches with `Arc<RwLock<...>>` (`Database.cached_collections`, `BasePlugin` hooks, `BaseStorage.schemas`, and `Storage.inner`) and adjusts APIs to return cloned values instead of references. Tightens `Storage::ensure_primary_key` to **error on missing primary key** instead of auto-populating a placeholder.
> 
> **IndexDB + query:** Adds `Query::has_or_operator`, introduces readonly store access (`get_store_readonly`), adds explicit top-level `$or` handling by executing sub-queries and de-duping by primary key, and reworks index optimization to pick a “best” indexed field and build `IdbKeyRange` via new helpers (`get_key_range`, `get_indexed_fields_in_query`). Updates cursor scanning (`cursor_fetch_and_filter`) and request handling (`idb_request_result`) accordingly, and regenerates typed docs to reflect the new wasm exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3eb7fdcc3cd49a69df685ec449e9af27264109d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->