### PR TITLE
fix: improve schema validation

### DIFF
--- a/packages/ridb-core/.gitignore
+++ b/packages/ridb-core/.gitignore
@@ -1,5 +1,6 @@
 pkg 
 target
+.chromedriver
 
 ./build
 build/*

--- a/packages/ridb-core/src/collection/mod.rs
+++ b/packages/ridb-core/src/collection/mod.rs
@@ -47,20 +47,49 @@ export type InternalsRecord = {
  * type ObjectType = ExtractType<'object'>; // ObjectType is object
  * type ArrayType = ExtractType<'array'>; // ArrayType is Array<any>
  */
-export type ExtractType<T extends string> = 
-  T extends "string" ? string : 
-  T extends "number" ? number : 
-  T extends "boolean" ? boolean : 
-  T extends "object" ? object : 
-  T extends "array" ? any[] : 
+export type ExtractType<T extends string> =
+  T extends "string" ? string :
+  T extends "number" ? number :
+  T extends "boolean" ? boolean :
+  T extends "object" ? object :
+  T extends "array" ? any[] :
   undefined;
 
-export type IsOptional<T> = 
-  T extends { required: true } 
-    ? T extends { default: never } 
-      ? false 
-      : true
-    : true;
+/**
+ * ExtractProperty maps a full Property definition to its document type. Unlike
+ * {@link ExtractType} (which only looks at the `type` string), it recurses into
+ * `items` for arrays and `properties` for objects, producing precise nested types.
+ *
+ * @example
+ * type Tags = ExtractProperty<{ type: "array"; items: { type: "string" } }>; // string[]
+ * type Obj  = ExtractProperty<{ type: "object"; properties: { id: { type: "string" } } }>; // { id: string }
+ */
+export type ExtractProperty<P> =
+  P extends { type: "string" } ? string :
+  P extends { type: "number" } ? number :
+  P extends { type: "boolean" } ? boolean :
+  P extends { type: "array" } ? (P extends { items: infer I } ? ExtractProperty<I>[] : any[]) :
+  P extends { type: "object" } ? (P extends { properties: infer PR } ? { [K in keyof PR]: ExtractProperty<PR[K]> } : object) :
+  unknown;
+
+/**
+ * The union of property names marked required at the schema level (JSON Schema
+ * `required` array). Resolves to `never` when no `required` array is present.
+ */
+export type RequiredFieldNames<T extends SchemaType> =
+  T extends { required: infer R }
+    ? (R extends readonly string[] ? R[number] : never)
+    : never;
+
+/**
+ * IsCreateOptional decides whether a property may be omitted when creating a document.
+ * A field is optional if it declares a default value, or is not listed in the
+ * schema-level `required` array.
+ */
+export type IsCreateOptional<T extends SchemaType, K extends keyof T["properties"]> =
+  T["properties"][K] extends { default: unknown }
+    ? true
+    : K extends RequiredFieldNames<T> ? false : true;
 
 /**
  * Doc is a utility type that transforms a schema type into a document type where each property is mapped to its extracted type.
@@ -70,8 +99,8 @@ export type IsOptional<T> =
  * type Document = Doc<Schema>; // Document is { name: string; age: number; }
  */
 export type Doc<T extends SchemaType> = {
-  [K in keyof T["properties"]]: 
-    ExtractType<T['properties'][K]['type']>
+  [K in keyof T["properties"]]:
+    ExtractProperty<T['properties'][K]>
 } & {
   __version?: number;
   createdAt?: number;
@@ -80,16 +109,17 @@ export type Doc<T extends SchemaType> = {
 
 /**
  * CreateDoc is a utility type for document creation that properly handles required vs optional fields
- * during the creation process. Fields with default values or required: false become optional.
+ * during the creation process. Fields with default values, or fields not listed in the schema-level
+ * `required` array, become optional.
  *
  * @template T - A schema type with a 'properties' field where each property's type is represented as a string.
  */
 export type CreateDoc<T extends SchemaType> = {
-  [K in keyof T["properties"] as IsOptional<T["properties"][K]> extends true ? K : never]?: 
-    ExtractType<T['properties'][K]['type']>
+  [K in keyof T["properties"] as IsCreateOptional<T, K> extends true ? K : never]?:
+    ExtractProperty<T['properties'][K]>
 } & {
-  [K in keyof T["properties"] as IsOptional<T["properties"][K]> extends true ? never : K]: 
-    ExtractType<T['properties'][K]['type']>
+  [K in keyof T["properties"] as IsCreateOptional<T, K> extends true ? never : K]:
+    ExtractProperty<T['properties'][K]>
 } &  {
   __version?: number;
   createdAt?: number;

--- a/packages/ridb-core/src/collection/mod.rs
+++ b/packages/ridb-core/src/collection/mod.rs
@@ -83,19 +83,37 @@ export type NestedRequiredNames<P> =
     : never;
 
 /**
+ * FlagRequiredness interprets a property's `required` declaration when it is used as a
+ * legacy boolean flag. Because `Property.required` is typed `boolean | string[]`, a
+ * schema literal written without `as const` widens `true`/`false` to `boolean`; the
+ * tuple-wrapped checks below classify each case:
+ *  - a literal `false` -> `"optional"`;
+ *  - a literal `true`, or a widened `boolean` (whose literal was lost) -> `"required"`.
+ *    Treating the ambiguous `boolean` as required matches the Rust validator and turns a
+ *    would-be runtime "missing required property" error into a compile-time one instead;
+ *  - the array form, or no `required` key -> `"defer"` to the container `required` array.
+ */
+export type FlagRequiredness<P> =
+  P extends { required: infer F }
+    ? ([F] extends [readonly string[]] ? "defer"
+       : [F] extends [false] ? "optional"
+       : [true] extends [F] ? "required"
+       : "defer")
+    : "defer";
+
+/**
  * IsNestedOptional decides whether a nested property `K` (within an object property's
  * `properties` map `PR`, given that object's required-name union `R`) may be omitted.
  * Precedence mirrors the runtime validator and {@link IsCreateOptional}:
  *  1. a declared `default` makes the field optional;
- *  2. a property-level `required: false` forces it optional;
- *  3. a property-level `required: true` forces it required;
- *  4. otherwise it is required iff listed in the object's `required` array;
- *  5. otherwise it is optional.
+ *  2. a boolean `required` flag wins (`false` -> optional, `true`/`boolean` -> required);
+ *  3. otherwise it is required iff listed in the object's `required` array;
+ *  4. otherwise it is optional.
  */
 export type IsNestedOptional<PR, K extends keyof PR, R> =
   PR[K] extends { default: unknown } ? true
-    : PR[K] extends { required: false } ? true
-    : PR[K] extends { required: true } ? false
+    : FlagRequiredness<PR[K]> extends "optional" ? true
+    : FlagRequiredness<PR[K]> extends "required" ? false
     : K extends R ? false
     : true;
 
@@ -127,27 +145,35 @@ export type RequiredFieldNames<T extends SchemaType> =
  * IsCreateOptional decides whether a property may be omitted when creating a document.
  * Precedence (mirrors the runtime validator):
  *  1. a declared `default` makes the field optional;
- *  2. a property-level `required: false` forces it optional;
- *  3. a property-level `required: true` forces it required;
- *  4. otherwise it is required iff listed in the schema-level `required` array;
- *  5. otherwise it is optional.
+ *  2. a boolean `required` flag wins (`false` -> optional, `true`/`boolean` -> required;
+ *     see {@link FlagRequiredness});
+ *  3. otherwise it is required iff listed in the schema-level `required` array;
+ *  4. otherwise it is optional.
  */
 export type IsCreateOptional<T extends SchemaType, K extends keyof T["properties"]> =
   T["properties"][K] extends { default: unknown } ? true
-    : T["properties"][K] extends { required: false } ? true
-    : T["properties"][K] extends { required: true } ? false
+    : FlagRequiredness<T["properties"][K]> extends "optional" ? true
+    : FlagRequiredness<T["properties"][K]> extends "required" ? false
     : K extends RequiredFieldNames<T> ? false
     : true;
 
 /**
- * Doc is a utility type that transforms a schema type into a document type where each property is mapped to its extracted type.
+ * Doc is a utility type that transforms a schema type into a stored-document type. A
+ * property is mandatory only when the validator guarantees its presence; properties that
+ * are optional at creation (not listed in `required`, flagged `required: false`, or
+ * carrying a `default`) may be absent on a stored document, so they are optional here
+ * too. This keeps `find`/`findById`/`create` return types from claiming keys that may not
+ * exist. Optionality uses the same {@link IsCreateOptional} rules as {@link CreateDoc}.
  *
  * @template T - A schema type with a 'properties' field where each property's type is represented as a string.
  *
  * type Document = Doc<Schema>; // Document is { name: string; age: number; }
  */
 export type Doc<T extends SchemaType> = {
-  [K in keyof T["properties"]]:
+  [K in keyof T["properties"] as IsCreateOptional<T, K> extends true ? never : K]:
+    ExtractProperty<T['properties'][K]>
+} & {
+  [K in keyof T["properties"] as IsCreateOptional<T, K> extends true ? K : never]?:
     ExtractProperty<T['properties'][K]>
 } & {
   __version?: number;

--- a/packages/ridb-core/src/collection/mod.rs
+++ b/packages/ridb-core/src/collection/mod.rs
@@ -83,13 +83,19 @@ export type RequiredFieldNames<T extends SchemaType> =
 
 /**
  * IsCreateOptional decides whether a property may be omitted when creating a document.
- * A field is optional if it declares a default value, or is not listed in the
- * schema-level `required` array.
+ * Precedence (mirrors the runtime validator):
+ *  1. a declared `default` makes the field optional;
+ *  2. a property-level `required: false` forces it optional;
+ *  3. a property-level `required: true` forces it required;
+ *  4. otherwise it is required iff listed in the schema-level `required` array;
+ *  5. otherwise it is optional.
  */
 export type IsCreateOptional<T extends SchemaType, K extends keyof T["properties"]> =
-  T["properties"][K] extends { default: unknown }
-    ? true
-    : K extends RequiredFieldNames<T> ? false : true;
+  T["properties"][K] extends { default: unknown } ? true
+    : T["properties"][K] extends { required: false } ? true
+    : T["properties"][K] extends { required: true } ? false
+    : K extends RequiredFieldNames<T> ? false
+    : true;
 
 /**
  * Doc is a utility type that transforms a schema type into a document type where each property is mapped to its extracted type.

--- a/packages/ridb-core/src/collection/mod.rs
+++ b/packages/ridb-core/src/collection/mod.rs
@@ -69,8 +69,50 @@ export type ExtractProperty<P> =
   P extends { type: "number" } ? number :
   P extends { type: "boolean" } ? boolean :
   P extends { type: "array" } ? (P extends { items: infer I } ? ExtractProperty<I>[] : any[]) :
-  P extends { type: "object" } ? (P extends { properties: infer PR } ? { [K in keyof PR]: ExtractProperty<PR[K]> } : object) :
+  P extends { type: "object" } ? (P extends { properties: infer PR } ? ExtractObject<PR, NestedRequiredNames<P>> : object) :
   unknown;
+
+/**
+ * NestedRequiredNames extracts the union of nested property names listed in an object
+ * property's `required` array (JSON Schema semantics), or `never` when no array is
+ * present. Note it only matches the array form; a boolean `required` flag yields `never`.
+ */
+export type NestedRequiredNames<P> =
+  P extends { required: infer R }
+    ? (R extends readonly string[] ? R[number] : never)
+    : never;
+
+/**
+ * IsNestedOptional decides whether a nested property `K` (within an object property's
+ * `properties` map `PR`, given that object's required-name union `R`) may be omitted.
+ * Precedence mirrors the runtime validator and {@link IsCreateOptional}:
+ *  1. a declared `default` makes the field optional;
+ *  2. a property-level `required: false` forces it optional;
+ *  3. a property-level `required: true` forces it required;
+ *  4. otherwise it is required iff listed in the object's `required` array;
+ *  5. otherwise it is optional.
+ */
+export type IsNestedOptional<PR, K extends keyof PR, R> =
+  PR[K] extends { default: unknown } ? true
+    : PR[K] extends { required: false } ? true
+    : PR[K] extends { required: true } ? false
+    : K extends R ? false
+    : true;
+
+/**
+ * ExtractObject builds an object document type from a `properties` map `PR` and the
+ * owning object's required-name union `R`, applying the correct optional/required
+ * modifier to each nested property (see {@link IsNestedOptional}). This keeps `Doc` and
+ * `CreateDoc` in step with the runtime validator, which only enforces nested keys named
+ * in that object's `required` array.
+ */
+export type ExtractObject<PR, R> = {
+  [K in keyof PR as IsNestedOptional<PR, K, R> extends true ? never : K]:
+    ExtractProperty<PR[K]>
+} & {
+  [K in keyof PR as IsNestedOptional<PR, K, R> extends true ? K : never]?:
+    ExtractProperty<PR[K]>
+};
 
 /**
  * The union of property names marked required at the schema level (JSON Schema

--- a/packages/ridb-core/src/schema/mod.rs
+++ b/packages/ridb-core/src/schema/mod.rs
@@ -165,13 +165,20 @@ impl Schema {
 
     /// Validates a JS object value against a set of properties.
     ///
-    /// Requiredness precedence for each property (see [`Required`]):
-    ///  1. a property-level boolean flag wins (`false` -> optional, `true` -> required);
-    ///  2. otherwise, the property is required iff it is listed in the container's
+    /// Requiredness precedence for each property (mirrors the compile-time
+    /// `IsCreateOptional`/`IsNestedOptional` types; see [`Required`]):
+    ///  1. a declared `default` makes the property optional (it is filled in before
+    ///     persistence, so its absence at validation time is never an error);
+    ///  2. otherwise, a property-level boolean flag wins (`false` -> optional,
+    ///     `true` -> required);
+    ///  3. otherwise, the property is required iff it is listed in the container's
     ///     `required` array (JSON Schema semantics);
-    ///  3. otherwise (no array, no flag) the property is optional. An omitted `required`
-    ///     array is therefore equivalent to `[]`, matching JSON Schema (and the
-    ///     compile-time `CreateDoc`/`IsCreateOptional` types).
+    ///  4. otherwise (no default, no array, no flag) the property is optional. An omitted
+    ///     `required` array is therefore equivalent to `[]`, matching JSON Schema.
+    ///
+    /// Note that `DefaultsPlugin` only fills top-level defaults; treating a defaulted
+    /// nested field as optional here keeps validation in step with the types even though
+    /// nested defaults are not materialised before validation.
     ///
     /// Encrypted fields are exempt from the presence check (they are populated later in
     /// the pipeline). Nested object properties are validated recursively against their
@@ -195,9 +202,14 @@ impl Schema {
                 })?;
 
             // Determine whether this property is required, applying the precedence above.
-            let is_required = match &prop.required {
-                Some(Required::Flag(flag)) => *flag,
-                _ => container_required.is_some_and(|arr| arr.contains(key)),
+            // A declared `default` takes priority and makes the property optional.
+            let is_required = if prop.default.is_some() {
+                false
+            } else {
+                match &prop.required {
+                    Some(Required::Flag(flag)) => *flag,
+                    _ => container_required.is_some_and(|arr| arr.contains(key)),
+                }
             };
 
             // Only an absent (`undefined`) value counts as "missing". A `null` value is
@@ -740,4 +752,38 @@ fn test_validate_document_null_is_type_checked() {
     assert!(schema.validate_document(JSON::parse(r#"{ "id": null }"#).unwrap()).is_err());
     // Omitting the optional `name` entirely remains valid.
     assert!(schema.validate_document(JSON::parse(r#"{ "id": "1" }"#).unwrap()).is_ok());
+}
+
+#[wasm_bindgen_test]
+fn test_validate_document_default_makes_required_optional() {
+    // Bug: a field with a declared `default` must be omittable even when it is listed in
+    // a `required` array, matching `IsCreateOptional`/`IsNestedOptional`. `DefaultsPlugin`
+    // only fills top-level defaults, so nested defaulted fields would otherwise fail
+    // validation despite TypeScript allowing them to be omitted.
+    let schema_js = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "required": ["id", "profile"],
+        "properties": {
+            "id": {"type": "string"},
+            "profile": {
+                "type": "object",
+                "required": ["email", "role"],
+                "properties": {
+                    "email": {"type": "string"},
+                    "role": {"type": "string", "default": "member"}
+                }
+            }
+        }
+    }"#;
+    let schema = Schema::create(JSON::parse(schema_js).unwrap()).unwrap();
+
+    // Nested `role` is listed as required but has a default -> omitting it is valid.
+    let doc = r#"{ "id": "1", "profile": { "email": "a@b.c" } }"#;
+    assert!(schema.validate_document(JSON::parse(doc).unwrap()).is_ok());
+
+    // Nested `email` is required with no default -> omitting it still errors.
+    let invalid = r#"{ "id": "1", "profile": { "role": "admin" } }"#;
+    assert!(schema.validate_document(JSON::parse(invalid).unwrap()).is_err());
 }

--- a/packages/ridb-core/src/schema/mod.rs
+++ b/packages/ridb-core/src/schema/mod.rs
@@ -33,6 +33,11 @@ export type SchemaType = {
      type: SchemaFieldType;
      indexes?:  string[];
      encrypted?:  string[];
+     /**
+      * The names of the required top-level properties. Follows JSON Schema
+      * semantics: only the listed properties are required.
+      */
+     required?: string[];
     /**
      * The properties defined in the schema.
      */
@@ -105,10 +110,13 @@ export class Schema<T extends SchemaType> {
      * The properties defined in the schema.
      */
     readonly properties: {
-        [K in keyof T['properties'] as T['properties'][K]['required'] extends false | (T['properties'][K]['default'] extends undefined ? true: false)  ? K : never]?: T['properties'][K];
-    } & {
-        [K in keyof T['properties'] as T['properties'][K]['required'] extends false ? never : K]: T['properties'][K];
+        [K in keyof T['properties']]: T['properties'][K];
     };
+
+    /**
+     * The names of the required top-level properties.
+     */
+    readonly required?: (Extract<keyof T['properties'], string>)[];
     /**
      * Converts the schema to a JSON representation.
      *
@@ -138,7 +146,11 @@ pub struct Schema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) indexes: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) encrypted: Option<Vec<String>>
+    pub(crate) encrypted: Option<Vec<String>>,
+    /// The names of the required top-level properties (JSON Schema semantics:
+    /// only listed properties are required).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) required: Option<Vec<String>>
 }
 
 
@@ -147,18 +159,25 @@ impl Schema {
 
     #[wasm_bindgen(js_name="validate")]
     pub fn validate_document(&self, document: JsValue) -> Result<(), RIDBError> {
-        // Collect required fields
-        let required: Vec<String> = self.properties
-            .iter()
-            .filter(|(_, prop)| prop.required.unwrap_or(true))
-            .map(|(key, _)| key.clone())
-            .collect();
+        let required = self.required.clone().unwrap_or_default();
+        let encrypted = self.encrypted.clone().unwrap_or_default();
+        self.validate_object(&document, &self.properties, &required, &encrypted)
+    }
 
-        let encrypted = self.encrypted.clone().unwrap_or(Vec::new());
-
-        for (key, prop) in &self.properties {
-
-            let value = Reflect::get(&document, &JsValue::from_str(&key))
+    /// Validates a JS object value against a set of properties, following JSON Schema
+    /// semantics: only the names listed in `required` must be present. Encrypted fields
+    /// are exempt from the presence check (they are populated later in the pipeline).
+    /// Nested object properties are validated recursively against their own
+    /// `properties`/`required`.
+    fn validate_object(
+        &self,
+        document: &JsValue,
+        properties: &HashMap<String, Property>,
+        required: &[String],
+        encrypted: &[String],
+    ) -> Result<(), RIDBError> {
+        for (key, prop) in properties {
+            let value = Reflect::get(document, &JsValue::from_str(key))
                 .map_err(|_e| {
                     JsValue::from(
                         RIDBError::validation(
@@ -168,31 +187,35 @@ impl Schema {
                     )
                 })?;
 
-            if value.is_undefined() {
+            if value.is_undefined() || value.is_null() {
                 // If the property is required and not encrypted, it's an error
-                if required.contains(&key) && !encrypted.contains(&key) {
+                if required.contains(key) && !encrypted.contains(key) {
                     return Err(
-                            RIDBError::validation(
-                                &format!("Missing required property '{}'", key),
-                                15
-                            )
-
+                        RIDBError::validation(
+                            &format!("Missing required property '{}'", key),
+                            15
+                        )
                     );
                 }
             } else {
-                let res = self.is_type_correct(&key, &value, &prop);
-                if let Err(err) = res {
-                    return Err(err);
-                } else if !res.unwrap() {
+                if !self.is_type_correct(key, &value, prop)? {
                     return Err(
-                            RIDBError::validation(
-                                &format!(
-                                    "Field '{}' should be of type '{:?}'",
-                                    key, prop.property_type
-                                ),
-                                15
-                            )
+                        RIDBError::validation(
+                            &format!(
+                                "Field '{}' should be of type '{:?}'",
+                                key, prop.property_type
+                            ),
+                            15
+                        )
                     );
+                }
+
+                // Recurse into nested object properties.
+                if prop.property_type == SchemaFieldType::Object {
+                    if let Some(nested_props) = &prop.properties {
+                        let nested_required = prop.required.clone().unwrap_or_default();
+                        self.validate_object(&value, nested_props, &nested_required, &[])?;
+                    }
                 }
             }
         }
@@ -281,6 +304,20 @@ impl Schema {
             property.is_valid()?;
         }
 
+        // Every name listed in `required` must be a defined property.
+        if let Some(required) = &self.required {
+            for name in required {
+                if !self.properties.contains_key(name) {
+                    return Err(
+                        RIDBError::validation(
+                            &format!("Required property '{}' is not defined in properties", name),
+                            30
+                        )
+                    );
+                }
+            }
+        }
+
         Ok(true)
     }
 
@@ -347,6 +384,16 @@ impl Schema {
     #[wasm_bindgen(getter, js_name="encrypted")]
     pub fn get_encrypted(&self) -> Option<Vec<String>> {
         self.encrypted.clone()
+    }
+
+    /// Retrieves the required top-level property names, if any.
+    ///
+    /// # Returns
+    ///
+    /// * `Option<Vec<String>>` - The required property names, if any.
+    #[wasm_bindgen(getter, js_name="required")]
+    pub fn get_required(&self) -> Option<Vec<String>> {
+        self.required.clone()
     }
 
     /// Retrieves the properties of the schema.
@@ -451,4 +498,108 @@ fn test_invalid_schema() {
     let result = Schema::create(schema_value);
 
     assert!(result.is_err());
+}
+
+#[wasm_bindgen_test]
+fn test_schema_required_subset_of_properties() {
+    // `required` naming a property that is not defined must fail validation.
+    let schema_js = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "required": ["id", "missing"],
+        "properties": {
+            "id": {"type": "string"}
+        }
+    }"#;
+    let schema_value = JSON::parse(schema_js).unwrap();
+    let result = Schema::create(schema_value);
+    assert!(result.is_err());
+}
+
+#[wasm_bindgen_test]
+fn test_validate_document_required_present() {
+    let schema_js = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+            "id": {"type": "string"},
+            "name": {"type": "string"},
+            "nickname": {"type": "string"}
+        }
+    }"#;
+    let schema = Schema::create(JSON::parse(schema_js).unwrap()).unwrap();
+
+    // Required fields present, optional `nickname` omitted -> valid.
+    let doc = r#"{ "id": "1", "name": "Alice" }"#;
+    assert!(schema.validate_document(JSON::parse(doc).unwrap()).is_ok());
+}
+
+#[wasm_bindgen_test]
+fn test_validate_document_required_missing() {
+    let schema_js = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+            "id": {"type": "string"},
+            "name": {"type": "string"}
+        }
+    }"#;
+    let schema = Schema::create(JSON::parse(schema_js).unwrap()).unwrap();
+
+    // Required `name` missing -> error.
+    let doc = r#"{ "id": "1" }"#;
+    assert!(schema.validate_document(JSON::parse(doc).unwrap()).is_err());
+}
+
+#[wasm_bindgen_test]
+fn test_validate_document_no_required_all_optional() {
+    // JSON Schema semantics: no `required` array means every property is optional.
+    let schema_js = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "properties": {
+            "id": {"type": "string"},
+            "name": {"type": "string"}
+        }
+    }"#;
+    let schema = Schema::create(JSON::parse(schema_js).unwrap()).unwrap();
+
+    let doc = r#"{ "id": "1" }"#;
+    assert!(schema.validate_document(JSON::parse(doc).unwrap()).is_ok());
+}
+
+#[wasm_bindgen_test]
+fn test_validate_document_nested_required() {
+    // Nested object properties are validated against their own `required` list.
+    let schema_js = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "required": ["id", "profile"],
+        "properties": {
+            "id": {"type": "string"},
+            "profile": {
+                "type": "object",
+                "required": ["email"],
+                "properties": {
+                    "email": {"type": "string"},
+                    "bio": {"type": "string"}
+                }
+            }
+        }
+    }"#;
+    let schema = Schema::create(JSON::parse(schema_js).unwrap()).unwrap();
+
+    let valid = r#"{ "id": "1", "profile": { "email": "a@b.c" } }"#;
+    assert!(schema.validate_document(JSON::parse(valid).unwrap()).is_ok());
+
+    // Nested required `email` missing -> error.
+    let invalid = r#"{ "id": "1", "profile": { "bio": "hi" } }"#;
+    assert!(schema.validate_document(JSON::parse(invalid).unwrap()).is_err());
 }

--- a/packages/ridb-core/src/schema/mod.rs
+++ b/packages/ridb-core/src/schema/mod.rs
@@ -167,10 +167,11 @@ impl Schema {
     ///
     /// Requiredness precedence for each property (see [`Required`]):
     ///  1. a property-level boolean flag wins (`false` -> optional, `true` -> required);
-    ///  2. otherwise, if the container declares a `required` array, the property is
-    ///     required iff it is listed (JSON Schema semantics);
-    ///  3. otherwise (no array, no flag) the property is required (legacy default),
-    ///     preserving the behaviour of schemas written before array support.
+    ///  2. otherwise, the property is required iff it is listed in the container's
+    ///     `required` array (JSON Schema semantics);
+    ///  3. otherwise (no array, no flag) the property is optional. An omitted `required`
+    ///     array is therefore equivalent to `[]`, matching JSON Schema (and the
+    ///     compile-time `CreateDoc`/`IsCreateOptional` types).
     ///
     /// Encrypted fields are exempt from the presence check (they are populated later in
     /// the pipeline). Nested object properties are validated recursively against their
@@ -196,7 +197,7 @@ impl Schema {
             // Determine whether this property is required, applying the precedence above.
             let is_required = match &prop.required {
                 Some(Required::Flag(flag)) => *flag,
-                _ => container_required.map_or(true, |arr| arr.contains(key)),
+                _ => container_required.is_some_and(|arr| arr.contains(key)),
             };
 
             if value.is_undefined() || value.is_null() {
@@ -572,9 +573,11 @@ fn test_validate_document_required_missing() {
 }
 
 #[wasm_bindgen_test]
-fn test_validate_document_legacy_no_array_all_required() {
-    // Backward compatibility: with no `required` array and no per-property flags,
-    // every property is required (legacy default), so a missing field errors.
+fn test_validate_document_no_array_all_optional() {
+    // JSON Schema semantics: with no `required` array and no per-property flags,
+    // every property is optional. An omitted `required` array is equivalent to `[]`,
+    // so a document missing defined properties still validates. This matches the
+    // compile-time `CreateDoc`/`IsCreateOptional` types.
     let schema_js = r#"{
         "version": 1,
         "primaryKey": "id",
@@ -586,8 +589,57 @@ fn test_validate_document_legacy_no_array_all_required() {
     }"#;
     let schema = Schema::create(JSON::parse(schema_js).unwrap()).unwrap();
 
-    assert!(schema.validate_document(JSON::parse(r#"{ "id": "1" }"#).unwrap()).is_err());
+    assert!(schema.validate_document(JSON::parse(r#"{ "id": "1" }"#).unwrap()).is_ok());
     assert!(schema.validate_document(JSON::parse(r#"{ "id": "1", "name": "A" }"#).unwrap()).is_ok());
+    // A present property must still type-check.
+    assert!(schema.validate_document(JSON::parse(r#"{ "id": 1 }"#).unwrap()).is_err());
+}
+
+#[wasm_bindgen_test]
+fn test_validate_document_omitted_nested_required_equals_empty() {
+    // Bug 1 regression: an object property with no nested `required` array must behave
+    // identically to an explicit empty `required: []` (nothing required), so a partial
+    // nested object validates instead of demanding every nested key.
+    let omitted = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "required": ["id", "profile"],
+        "properties": {
+            "id": {"type": "string"},
+            "profile": {
+                "type": "object",
+                "properties": {
+                    "email": {"type": "string"},
+                    "bio": {"type": "string"}
+                }
+            }
+        }
+    }"#;
+    let empty = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "required": ["id", "profile"],
+        "properties": {
+            "id": {"type": "string"},
+            "profile": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                    "email": {"type": "string"},
+                    "bio": {"type": "string"}
+                }
+            }
+        }
+    }"#;
+    let doc = r#"{ "id": "1", "profile": { "bio": "hi" } }"#;
+
+    let schema_omitted = Schema::create(JSON::parse(omitted).unwrap()).unwrap();
+    let schema_empty = Schema::create(JSON::parse(empty).unwrap()).unwrap();
+
+    assert!(schema_omitted.validate_document(JSON::parse(doc).unwrap()).is_ok());
+    assert!(schema_empty.validate_document(JSON::parse(doc).unwrap()).is_ok());
 }
 
 #[wasm_bindgen_test]

--- a/packages/ridb-core/src/schema/mod.rs
+++ b/packages/ridb-core/src/schema/mod.rs
@@ -124,7 +124,13 @@ export class Schema<T extends SchemaType> {
      */
     toJSON(): SchemaType;
 
-    validate(document: Doc<Schema<T>>): boolean;
+    /**
+     * Validates a document against the schema. The runtime applies the same
+     * optional/required rules as creation (only `required` fields, without a `default`,
+     * must be present), so the accepted shape is `CreateDoc<T>` rather than a fully-keyed
+     * `Doc<T>`.
+     */
+    validate(document: CreateDoc<T>): boolean;
 }
 "#;
 

--- a/packages/ridb-core/src/schema/mod.rs
+++ b/packages/ridb-core/src/schema/mod.rs
@@ -200,7 +200,11 @@ impl Schema {
                 _ => container_required.is_some_and(|arr| arr.contains(key)),
             };
 
-            if value.is_undefined() || value.is_null() {
+            // Only an absent (`undefined`) value counts as "missing". A `null` value is
+            // present and must be validated against the declared type, so it falls through
+            // to `is_type_correct` below (which rejects `null` for `string`, `object`,
+            // etc.). This prevents optional fields from silently persisting `null`.
+            if value.is_undefined() {
                 if is_required && !encrypted.contains(key) {
                     return Err(
                         RIDBError::validation(
@@ -711,4 +715,29 @@ fn test_validate_document_nested_required() {
     // Nested required `email` missing -> error.
     let invalid = r#"{ "id": "1", "profile": { "bio": "hi" } }"#;
     assert!(schema.validate_document(JSON::parse(invalid).unwrap()).is_err());
+}
+
+#[wasm_bindgen_test]
+fn test_validate_document_null_is_type_checked() {
+    // Bug 2 regression: `null` is a present value, not a missing one. It must be
+    // validated against the declared type and fail for non-nullable types, even for
+    // optional properties. Otherwise an optional field could silently persist `null`.
+    let schema_js = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+            "id": {"type": "string"},
+            "name": {"type": "string"}
+        }
+    }"#;
+    let schema = Schema::create(JSON::parse(schema_js).unwrap()).unwrap();
+
+    // Optional `name` explicitly set to null -> type error (not silently accepted).
+    assert!(schema.validate_document(JSON::parse(r#"{ "id": "1", "name": null }"#).unwrap()).is_err());
+    // Required `id` set to null -> still an error.
+    assert!(schema.validate_document(JSON::parse(r#"{ "id": null }"#).unwrap()).is_err());
+    // Omitting the optional `name` entirely remains valid.
+    assert!(schema.validate_document(JSON::parse(r#"{ "id": "1" }"#).unwrap()).is_ok());
 }

--- a/packages/ridb-core/src/schema/mod.rs
+++ b/packages/ridb-core/src/schema/mod.rs
@@ -9,7 +9,7 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen_test::{ wasm_bindgen_test};
 use crate::error::RIDBError;
-use crate::schema::property::Property;
+use crate::schema::property::{Property, Required};
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"
@@ -159,21 +159,27 @@ impl Schema {
 
     #[wasm_bindgen(js_name="validate")]
     pub fn validate_document(&self, document: JsValue) -> Result<(), RIDBError> {
-        let required = self.required.clone().unwrap_or_default();
         let encrypted = self.encrypted.clone().unwrap_or_default();
-        self.validate_object(&document, &self.properties, &required, &encrypted)
+        self.validate_object(&document, &self.properties, self.required.as_ref(), &encrypted)
     }
 
-    /// Validates a JS object value against a set of properties, following JSON Schema
-    /// semantics: only the names listed in `required` must be present. Encrypted fields
-    /// are exempt from the presence check (they are populated later in the pipeline).
-    /// Nested object properties are validated recursively against their own
-    /// `properties`/`required`.
+    /// Validates a JS object value against a set of properties.
+    ///
+    /// Requiredness precedence for each property (see [`Required`]):
+    ///  1. a property-level boolean flag wins (`false` -> optional, `true` -> required);
+    ///  2. otherwise, if the container declares a `required` array, the property is
+    ///     required iff it is listed (JSON Schema semantics);
+    ///  3. otherwise (no array, no flag) the property is required (legacy default),
+    ///     preserving the behaviour of schemas written before array support.
+    ///
+    /// Encrypted fields are exempt from the presence check (they are populated later in
+    /// the pipeline). Nested object properties are validated recursively against their
+    /// own `properties` and (array-form) `required`.
     fn validate_object(
         &self,
         document: &JsValue,
         properties: &HashMap<String, Property>,
-        required: &[String],
+        container_required: Option<&Vec<String>>,
         encrypted: &[String],
     ) -> Result<(), RIDBError> {
         for (key, prop) in properties {
@@ -187,9 +193,14 @@ impl Schema {
                     )
                 })?;
 
+            // Determine whether this property is required, applying the precedence above.
+            let is_required = match &prop.required {
+                Some(Required::Flag(flag)) => *flag,
+                _ => container_required.map_or(true, |arr| arr.contains(key)),
+            };
+
             if value.is_undefined() || value.is_null() {
-                // If the property is required and not encrypted, it's an error
-                if required.contains(key) && !encrypted.contains(key) {
+                if is_required && !encrypted.contains(key) {
                     return Err(
                         RIDBError::validation(
                             &format!("Missing required property '{}'", key),
@@ -210,11 +221,15 @@ impl Schema {
                     );
                 }
 
-                // Recurse into nested object properties.
+                // Recurse into nested object properties. Only the array form of
+                // `required` names nested children; a boolean flag does not.
                 if prop.property_type == SchemaFieldType::Object {
                     if let Some(nested_props) = &prop.properties {
-                        let nested_required = prop.required.clone().unwrap_or_default();
-                        self.validate_object(&value, nested_props, &nested_required, &[])?;
+                        let nested_required = match &prop.required {
+                            Some(Required::Fields(fields)) => Some(fields),
+                            _ => None,
+                        };
+                        self.validate_object(&value, nested_props, nested_required, &[])?;
                     }
                 }
             }
@@ -557,8 +572,9 @@ fn test_validate_document_required_missing() {
 }
 
 #[wasm_bindgen_test]
-fn test_validate_document_no_required_all_optional() {
-    // JSON Schema semantics: no `required` array means every property is optional.
+fn test_validate_document_legacy_no_array_all_required() {
+    // Backward compatibility: with no `required` array and no per-property flags,
+    // every property is required (legacy default), so a missing field errors.
     let schema_js = r#"{
         "version": 1,
         "primaryKey": "id",
@@ -570,8 +586,49 @@ fn test_validate_document_no_required_all_optional() {
     }"#;
     let schema = Schema::create(JSON::parse(schema_js).unwrap()).unwrap();
 
-    let doc = r#"{ "id": "1" }"#;
-    assert!(schema.validate_document(JSON::parse(doc).unwrap()).is_ok());
+    assert!(schema.validate_document(JSON::parse(r#"{ "id": "1" }"#).unwrap()).is_err());
+    assert!(schema.validate_document(JSON::parse(r#"{ "id": "1", "name": "A" }"#).unwrap()).is_ok());
+}
+
+#[wasm_bindgen_test]
+fn test_validate_document_legacy_required_false() {
+    // Legacy per-property `required: false` keeps a field optional with no array present.
+    let schema_js = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "properties": {
+            "id": {"type": "string"},
+            "name": {"type": "string", "required": false}
+        }
+    }"#;
+    let schema = Schema::create(JSON::parse(schema_js).unwrap()).unwrap();
+
+    assert!(schema.validate_document(JSON::parse(r#"{ "id": "1" }"#).unwrap()).is_ok());
+}
+
+#[wasm_bindgen_test]
+fn test_validate_document_flag_overrides_array() {
+    // A property-level boolean flag overrides the container `required` array:
+    // `name` is listed as required but flagged optional; `nickname` is unlisted but
+    // flagged required.
+    let schema_js = r#"{
+        "version": 1,
+        "primaryKey": "id",
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+            "id": {"type": "string"},
+            "name": {"type": "string", "required": false},
+            "nickname": {"type": "string", "required": true}
+        }
+    }"#;
+    let schema = Schema::create(JSON::parse(schema_js).unwrap()).unwrap();
+
+    // `name` omitted (flag false wins over array) but `nickname` present -> ok.
+    assert!(schema.validate_document(JSON::parse(r#"{ "id": "1", "nickname": "nn" }"#).unwrap()).is_ok());
+    // `nickname` omitted (flag true) -> error even though it is not in the array.
+    assert!(schema.validate_document(JSON::parse(r#"{ "id": "1", "name": "A" }"#).unwrap()).is_err());
 }
 
 #[wasm_bindgen_test]

--- a/packages/ridb-core/src/schema/property.rs
+++ b/packages/ridb-core/src/schema/property.rs
@@ -59,10 +59,13 @@ export class Property {
     readonly minLength?: number;
 
     /**
-     * An optional array naming the required nested properties for object-type properties.
-     * Follows JSON Schema semantics: only the listed properties are required.
+     * Controls requiredness. Two forms are supported and interoperate:
+     *  - `boolean`: a per-property flag (legacy). `false` forces the property optional,
+     *    `true` forces it required, overriding any container-level `required` array.
+     *  - `string[]`: for object-type properties, the JSON Schema list of required
+     *    nested properties.
      */
-    readonly required?: string[];
+    readonly required?: boolean | string[];
 
     /**
      * An optional default value for the property.
@@ -78,6 +81,17 @@ export class Property {
 }
 "#;
 
+
+/// Requiredness declaration for a property. Supports both the legacy per-property
+/// boolean flag and the JSON Schema array of required nested property names.
+#[derive(Deserialize, Serialize, Clone, PartialEq, Debug)]
+#[serde(untagged)]
+pub enum Required {
+    /// Legacy per-property flag: whether this property is required within its parent.
+    Flag(bool),
+    /// JSON Schema list of required nested property names (object-type properties).
+    Fields(Vec<String>),
+}
 
 #[wasm_bindgen(skip_typescript)]
 #[derive(Deserialize, Serialize, Clone, PartialEq, Debug)]
@@ -115,10 +129,10 @@ pub struct Property {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) default: Option<Value>,
 
-    /// Optional list naming the required nested properties for object-type properties
-    /// (JSON Schema semantics: only listed properties are required).
+    /// Optional requiredness declaration: either a legacy per-property boolean flag
+    /// or a JSON Schema array of required nested property names.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) required: Option<Vec<String>>,
+    pub(crate) required: Option<Required>,
 }
 
 #[wasm_bindgen]
@@ -179,8 +193,8 @@ impl Property {
             SchemaFieldType::Object => match self.clone().properties {
                 Some(props) => {
                     if props.len() > 0 {
-                        // Every name listed in `required` must be a defined property.
-                        if let Some(required) = &self.required {
+                        // When `required` is an array, every listed name must be a defined property.
+                        if let Some(Required::Fields(required)) = &self.required {
                             for name in required {
                                 if !props.contains_key(name) {
                                     return Err(
@@ -293,7 +307,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 mod tests {
     use std::collections::HashMap;
     use crate::error::RIDBError;
-    use crate::schema::property::Property;
+    use crate::schema::property::{Property, Required};
     use crate::schema::property_type::{SchemaFieldType};
 
     #[test]
@@ -606,7 +620,7 @@ mod tests {
             min_length: None,
             properties: Some(props),
             default: None,
-            required: Some(vec!["email".to_string()]),
+            required: Some(Required::Fields(vec!["email".to_string()])),
         }.is_valid();
         assert!(result.unwrap());
     }
@@ -634,7 +648,7 @@ mod tests {
             min_length: None,
             properties: Some(props),
             default: None,
-            required: Some(vec!["missing".to_string()]),
+            required: Some(Required::Fields(vec!["missing".to_string()])),
         }.is_valid();
         match result {
             Ok(_) => panic!("Expected an error, but got Ok"),

--- a/packages/ridb-core/src/schema/property.rs
+++ b/packages/ridb-core/src/schema/property.rs
@@ -59,9 +59,10 @@ export class Property {
     readonly minLength?: number;
 
     /**
-     * An optional array of required fields for object-type properties.
+     * An optional array naming the required nested properties for object-type properties.
+     * Follows JSON Schema semantics: only the listed properties are required.
      */
-    readonly required?: boolean;
+    readonly required?: string[];
 
     /**
      * An optional default value for the property.
@@ -114,9 +115,10 @@ pub struct Property {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) default: Option<Value>,
 
-    /// Optional default value for the property.
+    /// Optional list naming the required nested properties for object-type properties
+    /// (JSON Schema semantics: only listed properties are required).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) required: Option<bool>,
+    pub(crate) required: Option<Vec<String>>,
 }
 
 #[wasm_bindgen]
@@ -177,6 +179,19 @@ impl Property {
             SchemaFieldType::Object => match self.clone().properties {
                 Some(props) => {
                     if props.len() > 0 {
+                        // Every name listed in `required` must be a defined property.
+                        if let Some(required) = &self.required {
+                            for name in required {
+                                if !props.contains_key(name) {
+                                    return Err(
+                                        RIDBError::validation(
+                                            &format!("Required property '{}' is not defined in properties", name),
+                                            30
+                                        )
+                                    );
+                                }
+                            }
+                        }
                         Ok(true)
                     } else {
                         Err(
@@ -292,7 +307,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
         assert_eq!(default_property.property_type, SchemaFieldType::String);
         assert!(default_property.items.is_none());
@@ -315,7 +330,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
         // Test default values to ensure proper initialization
         assert_eq!(default_property.property_type, SchemaFieldType::Array);
@@ -347,7 +362,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
         let default_property = Property {
             property_type: SchemaFieldType::Array,
@@ -358,7 +373,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
         let result = default_property.is_valid();
         match result {
@@ -383,7 +398,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
 
         let default_property2 = Property {
@@ -395,7 +410,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
         let result = default_property2.is_valid();
         // Check the result for an error message
@@ -423,7 +438,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
 
         let default_property2 = Property {
@@ -435,7 +450,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
         let result = default_property2.is_valid();
         // Check the result for an error message
@@ -462,7 +477,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
         let result = default_property2.is_valid();
         // Check the result for an error message
@@ -483,7 +498,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
         let result = default_property2.is_valid();
         // Check the result for an error message
@@ -504,7 +519,7 @@ mod tests {
             min_length: Some(2),
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
         let result = default_property2.is_valid();
         // Check the result for an error message
@@ -529,7 +544,7 @@ mod tests {
             min_length: Some(-1),
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         };
         let result = default_property2.is_valid();
         // Check the result for an error message
@@ -554,7 +569,7 @@ mod tests {
             min_length: None,
             properties: None,
             default: None,
-            required: Some(true)
+            required: None
         }.is_valid();
         // Check the result for an error message
         match result {
@@ -564,6 +579,68 @@ mod tests {
 
                 assert_eq!(error.message, "Validation Error: Properties empty", "Error: Expected 'Validation Error: Properties empty'")
 
+            }
+        }
+    }
+
+    #[test]
+    fn test_property_object_required_subset_ok() {
+        let mut props = HashMap::new();
+        props.insert("email".to_string(), Property {
+            property_type: SchemaFieldType::String,
+            items: None,
+            max_items: None,
+            min_items: None,
+            max_length: None,
+            min_length: None,
+            properties: None,
+            default: None,
+            required: None,
+        });
+        let result = Property {
+            property_type: SchemaFieldType::Object,
+            items: None,
+            max_items: None,
+            min_items: None,
+            max_length: None,
+            min_length: None,
+            properties: Some(props),
+            default: None,
+            required: Some(vec!["email".to_string()]),
+        }.is_valid();
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_property_object_required_unknown_err() {
+        let mut props = HashMap::new();
+        props.insert("email".to_string(), Property {
+            property_type: SchemaFieldType::String,
+            items: None,
+            max_items: None,
+            min_items: None,
+            max_length: None,
+            min_length: None,
+            properties: None,
+            default: None,
+            required: None,
+        });
+        let result = Property {
+            property_type: SchemaFieldType::Object,
+            items: None,
+            max_items: None,
+            min_items: None,
+            max_length: None,
+            min_length: None,
+            properties: Some(props),
+            default: None,
+            required: Some(vec!["missing".to_string()]),
+        }.is_valid();
+        match result {
+            Ok(_) => panic!("Expected an error, but got Ok"),
+            Err(js_val) => {
+                let error = RIDBError::from(js_val);
+                assert_eq!(error.message, "Validation Error: Required property 'missing' is not defined in properties");
             }
         }
     }
@@ -579,7 +656,7 @@ mod tests {
             min_length: None,
             properties: Some(HashMap::new()),
             default: None,
-            required: Some(true)
+            required: None
         }.is_valid();
         // Check the result for an error message
         match result {

--- a/packages/ridb-core/src/storage/internals/base_storage.rs
+++ b/packages/ridb-core/src/storage/internals/base_storage.rs
@@ -167,6 +167,7 @@ impl BaseStorage {
                         primary_key: "id".to_string(),
                         schema_type: "object".to_string(),
                         properties,
+                        required: None,
                     };
 
                     new_schemas.insert(index_name, index_schema);

--- a/packages/ridb-core/test.sh
+++ b/packages/ridb-core/test.sh
@@ -6,8 +6,59 @@ test_node() {
     wasm-pack --log-level error test --node -- --features node || { echo "wasm-pack test for node failed"; exit 1; }
 }
 
+# Ensure the chromedriver used by wasm-pack matches the installed Chrome.
+#
+# wasm-pack resolves `chromedriver` from PATH and ignores $CHROMEDRIVER. Chrome and
+# ChromeDriver must share the same major version, otherwise the driver is killed
+# (SIGKILL) immediately after launch and the whole suite fails. If the chromedriver
+# already on PATH matches Chrome we keep it; otherwise we download a matching
+# Chrome-for-Testing driver into a gitignored cache and prepend it to PATH.
+ensure_matching_chromedriver() {
+    local chrome_bin="" chrome_major="" driver_major="" install_out driver_dir candidate
+
+    for candidate in \
+        "$CHROME" \
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+        "$(command -v google-chrome 2>/dev/null || true)" \
+        "$(command -v google-chrome-stable 2>/dev/null || true)" \
+        "$(command -v chromium 2>/dev/null || true)"; do
+        if [ -n "$candidate" ] && [ -x "$candidate" ]; then chrome_bin="$candidate"; break; fi
+    done
+
+    if [ -z "$chrome_bin" ]; then
+        echo "Chrome not found; letting wasm-pack manage chromedriver."
+        return 0
+    fi
+
+    chrome_major="$("$chrome_bin" --version 2>/dev/null | grep -oE '[0-9]+' | head -1)"
+    if [ -z "$chrome_major" ]; then
+        echo "Could not determine Chrome version; letting wasm-pack manage chromedriver."
+        return 0
+    fi
+
+    if command -v chromedriver >/dev/null 2>&1; then
+        driver_major="$(chromedriver --version 2>/dev/null | grep -oE '[0-9]+' | head -1)"
+        if [ "$driver_major" = "$chrome_major" ]; then
+            echo "chromedriver on PATH matches Chrome ${chrome_major}."
+            return 0
+        fi
+        echo "chromedriver (${driver_major}) does not match Chrome (${chrome_major})."
+    fi
+
+    echo "Installing chromedriver@${chrome_major} to match Chrome ${chrome_major}..."
+    install_out="$(npx -y @puppeteer/browsers install "chromedriver@${chrome_major}" --path "$(pwd)/.chromedriver" 2>/dev/null | tail -1)"
+    driver_dir="$(dirname "$(echo "$install_out" | awk '{print $NF}')")"
+    if [ -n "$driver_dir" ] && [ -x "$driver_dir/chromedriver" ]; then
+        export PATH="$driver_dir:$PATH"
+        echo "Using chromedriver at $driver_dir/chromedriver"
+    else
+        echo "Warning: could not install a matching chromedriver; proceeding with the default on PATH."
+    fi
+}
+
 # Function to test browser environment
 test_browser() {
+    ensure_matching_chromedriver
     wasm-pack --log-level info test --headless --chrome -- --lib --features browser || { echo "wasm-pack test for browser failed"; exit 1; }
 }
 

--- a/packages/ridb/src/testing/test/schemas.test.ts
+++ b/packages/ridb/src/testing/test/schemas.test.ts
@@ -943,6 +943,7 @@ export const UnitTests = (platform: string, storages: StoragesType[], worker = f
                 version: 0 as const,
                 primaryKey: "id",
                 type: SchemaFieldType.object,
+                required: ["id", "name"],
                 properties: {
                   id: { type: SchemaFieldType.string },
                   name: { type: SchemaFieldType.string },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes default required-field behavior (previously implicit “all required” vs JSON Schema opt-in) and document validation rules, which can break existing schemas and persisted writes; TypeScript `Doc`/`CreateDoc` shapes also shift for consumers.
> 
> **Overview**
> Aligns **schema requiredness** with **JSON Schema**: only names in a schema-level `required` array are mandatory by default (omitted `required` means all properties optional), with legacy per-property `required: true/false` and nested `required: string[]` on objects still supported.
> 
> **Runtime validation** is rewritten to follow the same precedence as TypeScript (`default` → boolean flag → container `required` list), including **recursive nested object** checks, **`null` treated as present** (type-checked, not skipped), and schema/property checks that every `required` name exists in `properties`.
> 
> **`Doc` / `CreateDoc`** now use `ExtractProperty` (nested arrays/objects) and shared `IsCreateOptional` rules so compile-time shapes match the validator; `Schema.validate` is typed to accept `CreateDoc<T>`.
> 
> Adds broad **wasm/browser tests**, updates the missing-field integration test to use `required: ["id", "name"]`, wires `required` on generated index schemas, and hardens **`test.sh`** with Chrome-matched chromedriver (`.chromedriver` gitignored).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd6106987d6d49a6c5eb9806bc79f5b0ec12a8fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->