### PR TITLE
fix: ci issue

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -12,7 +12,11 @@ jobs:
   lint_pr:
     name: Validate PR title
     runs-on: macos-latest
+    # Dependabot generates conventional titles already and cannot access custom
+    # Actions secrets, so skip the check there rather than failing on a blank token.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_SECRET }}
+          # Fall back to the built-in token when GH_SECRET is unavailable.
+          GITHUB_TOKEN: ${{ secrets.GH_SECRET || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.GH_SECRET }}
+          # Fall back to the built-in token when GH_SECRET is unavailable (e.g. on
+          # Dependabot PRs, where custom Actions secrets are not exposed). This keeps
+          # checkout/submodule fetch working instead of prompting for credentials.
+          token: ${{ secrets.GH_SECRET || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -42,7 +45,7 @@ jobs:
       - name: Install WASM
         env:
           NPM_CONFIG_PROVENANCE: true
-          GH_TOKEN: ${{ secrets.GH_SECRET }}
+          GH_TOKEN: ${{ secrets.GH_SECRET || secrets.GITHUB_TOKEN }}
         run: |
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
           yarn install

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
           scope: '@trust0'
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Enable Corepack


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions configuration with no application runtime or security logic changes; built-in GITHUB_TOKEN may have narrower permissions than GH_SECRET for some submodule/private access edge cases.
> 
> **Overview**
> Fixes CI failures on **Dependabot PRs**, where custom `GH_SECRET` is not available and semantic title linting is redundant.
> 
> **PR / lint workflow:** Skips semantic PR title validation when `github.actor` is `dependabot[bot]`. Uses `secrets.GH_SECRET || secrets.GITHUB_TOKEN` for the semantic PR action token.
> 
> **Main CI (`pr.yml`):** Applies the same token fallback for checkout (including submodules) and for `GH_TOKEN` during the WASM install/build step. Bumps **Node.js from 22 to 24**.
> 
> **Release workflow:** Bumps Node.js to **24** only; release still uses `GH_SECRET` without the Dependabot fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ea7f03494820833cd7bec3276f6711387d365d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->